### PR TITLE
MACI v1 vote blocks, CLI tooling, and test compile pipeline fixes #23 #14

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- MACI v1 building blocks: `MACICommandPack`, `MACICommandUnpack`, `MACICommandHash`, `MACISharedKeyHash`, `MACIMessageEncrypt`, `MACIMessageDecrypt`, `MACIMessageHash`, `MACIVoteCommit`, `MACIVoteDecryptVerify(n)` — command packing/h_cm per [MACI v1 spec](https://maci.pse.dev/docs/v1.2/spec); additive Poseidon keystream encryption; coordinator verify with allowlist + nonce. 8 tests.
+
 ## 0.6.0
 
 - Arithmetic: PoEVerify(n) — SNARK-friendly proof-of-exponentiation verification (constrains result = base^exponent in the field; n-bit exponent, no big-int); for field-based accumulators (e.g. witness^element = A). 14 dedicated tests (edge cases, max exponent, 0^0, 1^exp, failure cases).

--- a/README.md
+++ b/README.md
@@ -174,18 +174,43 @@ Contributions welcome; open an issue to propose or prioritize.
 
 See [SECURITY.md](SECURITY.md) for more.
 
+## CLI
+
+Requires **circom 2.x** on `PATH` (peer dependency; not bundled).
+
+```bash
+npm install opencircom
+
+# Include path for -l flag
+npx opencircom path
+
+# Compile your circuit (adds opencircom/circuits to -l automatically)
+npx opencircom compile circuits/MyCircuit.circom -o build
+
+# Compile all library test wrappers (used by npm test)
+npx opencircom compile --all-test -o build
+
+# List exported templates with descriptions
+npx opencircom list
+
+# Scaffold a minimal Poseidon commitment circuit + mocha test
+npx opencircom init my_circuit
+```
+
+From this repo, `npm run compile:test` compiles every file in `test/circuits/` before tests run.
+
 ## Tests
 
 Tests use **real** ZK where applicable: circuits are compiled with Circom, then a small Powers of Tau and zkey are generated, and a Groth16 proof is created and verified with snarkjs (no mocks).
 
-**Coverage** (253+ tests): Poseidon, PoseidonEncrypt, SHA-256, Comparators, IdentityCommitment, SemaphoreMembership, AccumulatorMembership, Gates, Bitify, Merkle (inclusion, AllowlistMembership, sparse, incremental, update), MiMC, Mux1/Mux2, MuxN, Arithmetic (incl. PoEVerify), Utils (PadBits, PadBits10Star, PadPKCS7, OneOfN, IndexOf, Min2, Max2, MinN, MaxN, AllEqual, CountMatches, Tally, ConditionalSelect, BalanceProof, VoteInAllowlist), String (Utf8Validation, FixedStringMatch, BytesAllInRange), Switcher, VoteCommitAllowlist, Nullifier, Voting, and one full Groth16 prove/verify.
+**Coverage** (253+ tests): Poseidon, PoseidonEncrypt, SHA-256, Comparators, IdentityCommitment, SemaphoreMembership, AccumulatorMembership, Gates, Bitify, Merkle (inclusion, AllowlistMembership, sparse, incremental, update), MiMC, Mux1/Mux2, MuxN, Arithmetic (incl. PoEVerify), Utils (PadBits, PadBits10Star, PadPKCS7, OneOfN, IndexOf, Min2, Max2, MinN, MaxN, AllEqual, CountMatches, Tally, ConditionalSelect, BalanceProof, VoteInAllowlist), String (Utf8Validation, FixedStringMatch, BytesAllInRange), Switcher, VoteCommitAllowlist, Nullifier, Voting, MACI, and one full Groth16 prove/verify.
 
 ```bash
 npm install
 npm test
 ```
 
-The first run runs `setup:zk` (ptau + zkey generation) and can take about a minute.
+`npm test` runs `compile:test` (all test circuits), then `setup:zk` (ptau + zkey). First run can take about a minute.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Output is written to **docs/** (see [docs/README.md](./docs/README.md) after gen
 | Identity  | `IdentityCommitment()`, `SemaphoreMembership(levels)` | Semaphore-style commitment = Poseidon(identity, secret); prove (identity, secret) in allowlist tree. Use with Nullifier. |
 | Identity  | `Nullifier(domainSize)`  | Nullifier hash for double-spend prevention. |
 | Voting    | `VoteCommit(numChoices)`, `VoteCommitAllowlist(n)`, `VoteReveal()` | Commit-reveal; allowlist variant constrains choice to allowedChoices[n]; double-vote prevention (nullifier-based). |
+| MACI      | `MACICommandPack()`, `MACICommandUnpack()`, `MACICommandHash()`, `MACISharedKeyHash()` | MACI v1 command packing and hashes ([spec](https://maci.pse.dev/docs/v1.2/spec)). |
+| MACI      | `MACIMessageEncrypt()`, `MACIMessageDecrypt()`, `MACIMessageHash()` | Additive Poseidon keystream message encryption (composable; full DuplexSponge is coordinator-side in MACI). |
+| MACI      | `MACIVoteCommit()`, `MACIVoteDecryptVerify(n)` | Encrypt command+signature plaintext; coordinator verifies decrypted vote in allowlist with nonce/poll checks. |
 | String & data | `Utf8Validation(n)`, `FixedStringMatch(n)`, `BytesAllInRange(n, lo, hi)`, `ByteInRange(lo, hi)` | UTF-8 byte-sequence validation; fixed string equality; bytes in [lo, hi] (e.g. digits). |
 
 ## Implemented (roadmap coverage)
@@ -143,6 +146,7 @@ Output is written to **docs/** (see [docs/README.md](./docs/README.md) after gen
 - **Symmetric encryption**: Poseidon-based (`PoseidonEncrypt()` — ciphertext = plaintext + Poseidon(key); decryption off-chain).
 - **Identity & credentials**: Semaphore-style commitment (`IdentityCommitment()`, `SemaphoreMembership(levels)` — prove (identity, secret) in allowlist; use with Nullifier). Age/threshold proofs: use `RangeProof(n)` (a = threshold, b = max).
 - **Voting**: Commit-reveal with nullifier, allowlist variant (`VoteCommitAllowlist`), tally (`Tally`).
+- **MACI**: Command pack/unpack/hash, shared-key binding, message encrypt/decrypt, `MACIVoteCommit`, `MACIVoteDecryptVerify` (MACI v1 layout; EdDSA/ECDH off-circuit).
 - **String & data**: UTF-8 validation (`Utf8Validation(n)`), fixed string match (`FixedStringMatch(n)`), bytes-in-range (`BytesAllInRange(n, lo, hi)`, `ByteInRange(lo, hi)`).
 
 ## Roadmap (potential additions)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,13 @@
 
 - `Nullifier(secret, externalNullifier)` is for one-time use per (`secret`, externalNullifier). Use a unique `externalNullifier` per action (e.g. poll id, withdrawal nonce).
 
+### MACI building blocks
+
+- **Off-circuit coordinator**: Baby JubJub ECDH shared key, EdDSA sign `h_cm`, full MACI DuplexSponge encryption, message batch processing, and state/ballot tree updates remain application-layer ([MACI v1 spec](https://maci.pse.dev/docs/v1.2/spec)).
+- **In-circuit encryption** uses additive Poseidon keystream, not MACI DuplexSponge; interoperable command packing and `h_cm` match MACI v1.
+- **`MACIVoteDecryptVerify`**: enforce `minValidNonce` from ballot state; reject votes outside `allowedVoteOptions`; bind `expectedPollId`.
+- **Nonce monotonicity**: MACI applies messages in reverse order; coordinator must track ballot nonces correctly.
+
 ## Audits
 
 This library has not undergone a formal audit. Use in production at your own risk. Prefer additional review for high-value applications.

--- a/circuits/voting/maci_voting.circom
+++ b/circuits/voting/maci_voting.circom
@@ -1,0 +1,357 @@
+pragma circom 2.0.0;
+
+include "../hashing/poseidon.circom";
+include "../comparators.circom";
+include "../bitify.circom";
+include "../utils.circom";
+include "../gates.circom";
+
+// MACI v1 command/message building blocks (composable; not full ProcessMessages).
+// Spec: https://maci.pse.dev/docs/v1.2/spec
+// Encryption: additive Poseidon keystream; coordinator uses DuplexSponge off-chain in MACI.
+
+/**
+ * @title MACICommandPack
+ * @notice Pack five 50-bit MACI command fields into p (MACI v1 §2.5).
+ * @dev p = cm_i + cm_iv·2^50 + cm_n·2^100 + cm_w·2^150 + cm_id·2^200. Each input range-checked.
+ * @custom:input stateIndex cm_i — state leaf index (50 bits).
+ * @custom:input voteOption cm_iv — vote option index (50 bits).
+ * @custom:input nonce cm_n — action nonce (50 bits).
+ * @custom:input voteWeight cm_w — voice credit allocation (50 bits).
+ * @custom:input pollId cm_id — poll identifier (50 bits).
+ * @custom:output packed p — 250-bit packed command prefix.
+ */
+template MACICommandPack() {
+    signal input stateIndex;
+    signal input voteOption;
+    signal input nonce;
+    signal input voteWeight;
+    signal input pollId;
+    signal output packed;
+
+    component r0 = StrictNum2Bits(50);
+    component r1 = StrictNum2Bits(50);
+    component r2 = StrictNum2Bits(50);
+    component r3 = StrictNum2Bits(50);
+    component r4 = StrictNum2Bits(50);
+    r0.in <== stateIndex;
+    r1.in <== voteOption;
+    r2.in <== nonce;
+    r3.in <== voteWeight;
+    r4.in <== pollId;
+
+    var pow50 = 1;
+    for (var i = 0; i < 50; i++) {
+        pow50 = pow50 + pow50;
+    }
+    var pow100 = pow50 * pow50;
+    var pow150 = pow100 * pow50;
+    var pow200 = pow150 * pow50;
+
+    packed <== stateIndex
+        + voteOption * pow50
+        + nonce * pow100
+        + voteWeight * pow150
+        + pollId * pow200;
+}
+
+/**
+ * @title MACICommandUnpack
+ * @notice Unpack p into five 50-bit MACI command fields (MACI v1 §2.6.1).
+ * @dev Inverse of MACICommandPack; p must be in [0, 2^250).
+ */
+template MACICommandUnpack() {
+    signal input packed;
+    signal output stateIndex;
+    signal output voteOption;
+    signal output nonce;
+    signal output voteWeight;
+    signal output pollId;
+
+    component bits = StrictNum2Bits(50 * 5);
+    bits.in <== packed;
+
+    component b0 = Bits2Num(50);
+    component b1 = Bits2Num(50);
+    component b2 = Bits2Num(50);
+    component b3 = Bits2Num(50);
+    component b4 = Bits2Num(50);
+
+    for (var i = 0; i < 50; i++) {
+        b0.in[i] <== bits.out[i];
+        b1.in[i] <== bits.out[i + 50];
+        b2.in[i] <== bits.out[i + 2 * 50];
+        b3.in[i] <== bits.out[i + 3 * 50];
+        b4.in[i] <== bits.out[i + 4 * 50];
+    }
+
+    stateIndex <== b0.out;
+    voteOption <== b1.out;
+    nonce <== b2.out;
+    voteWeight <== b3.out;
+    pollId <== b4.out;
+}
+
+/**
+ * @title MACICommandHash
+ * @notice Command digest h_cm = poseidon4([p, pubKeyX, pubKeyY, salt]) (MACI v1 §2.5).
+ * @custom:input packed Packed command prefix p.
+ * @custom:input pubKeyX Public key x-coordinate.
+ * @custom:input pubKeyY Public key y-coordinate.
+ * @custom:input salt Command salt cm_s.
+ * @custom:output hash h_cm for EdDSA signing (off-circuit).
+ */
+template MACICommandHash() {
+    signal input packed;
+    signal input pubKeyX;
+    signal input pubKeyY;
+    signal input salt;
+    signal output hash;
+
+    component h = Poseidon(4);
+    h.inputs[0] <== packed;
+    h.inputs[1] <== pubKeyX;
+    h.inputs[2] <== pubKeyY;
+    h.inputs[3] <== salt;
+    hash <== h.out;
+}
+
+/**
+ * @title MACISharedKeyHash
+ * @notice Bind ECDH shared key k_s = [ks0, ks1] to a single field (MACI v1 §1.10).
+ * @dev ks0, ks1 are derived off-circuit via Baby JubJub ECDH; only the hash is used in-circuit.
+ * @custom:input ks0 Shared key element 0.
+ * @custom:input ks1 Shared key element 1.
+ * @custom:output hash poseidon2([ks0, ks1]).
+ */
+template MACISharedKeyHash() {
+    signal input ks0;
+    signal input ks1;
+    signal output hash;
+
+    component h = Poseidon(2);
+    h.inputs[0] <== ks0;
+    h.inputs[1] <== ks1;
+    hash <== h.out;
+}
+
+/**
+ * @title MACIMessageKeystream
+ * @notice Single keystream block for additive message encryption.
+ * @dev keystream = poseidon3([sharedKeyHash, nonce, index]). MACI v1 uses DuplexSponge off-chain.
+ */
+template MACIMessageKeystream() {
+    signal input sharedKeyHash;
+    signal input nonce;
+    signal input index;
+    signal output keystream;
+
+    component h = Poseidon(3);
+    h.inputs[0] <== sharedKeyHash;
+    h.inputs[1] <== nonce;
+    h.inputs[2] <== index;
+    keystream <== h.out;
+}
+
+/**
+ * @title MACIMessageEncrypt
+ * @notice Encrypt MACI v1 plaintext t (length 7): ciphertext[i] = t[i] + keystream(i).
+ * @dev Plaintext layout: t = [p, pubKeyX, pubKeyY, salt, sigR8x, sigR8y, sigS].
+ */
+template MACIMessageEncrypt() {
+    signal input sharedKeyHash;
+    signal input nonce;
+    signal input plaintext[7];
+    signal output ciphertext[7];
+
+    component ks[7];
+    for (var i = 0; i < 7; i++) {
+        ks[i] = MACIMessageKeystream();
+        ks[i].sharedKeyHash <== sharedKeyHash;
+        ks[i].nonce <== nonce;
+        ks[i].index <== i;
+        ciphertext[i] <== plaintext[i] + ks[i].keystream;
+    }
+}
+
+/**
+ * @title MACIMessageDecrypt
+ * @notice Decrypt MACI message: plaintext[i] = ciphertext[i] - keystream(i).
+ */
+template MACIMessageDecrypt() {
+    signal input sharedKeyHash;
+    signal input nonce;
+    signal input ciphertext[7];
+    signal output plaintext[7];
+
+    component ks[7];
+    for (var i = 0; i < 7; i++) {
+        ks[i] = MACIMessageKeystream();
+        ks[i].sharedKeyHash <== sharedKeyHash;
+        ks[i].nonce <== nonce;
+        ks[i].index <== i;
+        plaintext[i] <== ciphertext[i] - ks[i].keystream;
+    }
+}
+
+/**
+ * @title MACIMessageHash
+ * @notice Hash encrypted message for on-chain commitment / message tree leaf.
+ * @dev messageHash = poseidon7(ciphertext). Coordinator stores MM + ephemeral pubkey off-chain.
+ */
+template MACIMessageHash() {
+    signal input ciphertext[7];
+    signal output hash;
+
+    component h = Poseidon(7);
+    for (var i = 0; i < 7; i++) {
+        h.inputs[i] <== ciphertext[i];
+    }
+    hash <== h.out;
+}
+
+/**
+ * @title MACIVoteCommit
+ * @notice Commit phase: encrypt MACI v1 command+signature plaintext and bind shared key hash.
+ * @dev Builds t = [p, pubKeyX, pubKeyY, salt, sigR8x, sigR8y, sigS], encrypts with sharedKeyHash.
+ *      EdDSA sign h_cm off-circuit before encryption. Outputs ciphertext and messageHash.
+ * @custom:input stateIndex, voteOption, nonce, voteWeight, pollId — command fields (50-bit each).
+ * @custom:input pubKeyX, pubKeyY, salt — public key and salt.
+ * @custom:input sigR8x, sigR8y, sigS — EdDSA signature (computed off-circuit over h_cm).
+ * @custom:input sharedKeyHash — poseidon2([ks0, ks1]) from ECDH (off-circuit).
+ * @custom:output ciphertext[7] Encrypted message.
+ * @custom:output messageHash poseidon7(ciphertext) for on-chain publish.
+ * @custom:output commandHash h_cm = poseidon4([p, pubKeyX, pubKeyY, salt]).
+ */
+template MACIVoteCommit() {
+    signal input stateIndex;
+    signal input voteOption;
+    signal input nonce;
+    signal input voteWeight;
+    signal input pollId;
+    signal input pubKeyX;
+    signal input pubKeyY;
+    signal input salt;
+    signal input sigR8x;
+    signal input sigR8y;
+    signal input sigS;
+    signal input sharedKeyHash;
+
+    signal output ciphertext[7];
+    signal output messageHash;
+    signal output commandHash;
+
+    component pack = MACICommandPack();
+    pack.stateIndex <== stateIndex;
+    pack.voteOption <== voteOption;
+    pack.nonce <== nonce;
+    pack.voteWeight <== voteWeight;
+    pack.pollId <== pollId;
+
+    component cmdHash = MACICommandHash();
+    cmdHash.packed <== pack.packed;
+    cmdHash.pubKeyX <== pubKeyX;
+    cmdHash.pubKeyY <== pubKeyY;
+    cmdHash.salt <== salt;
+    commandHash <== cmdHash.hash;
+
+    signal plaintext[7];
+    plaintext[0] <== pack.packed;
+    plaintext[1] <== pubKeyX;
+    plaintext[2] <== pubKeyY;
+    plaintext[3] <== salt;
+    plaintext[4] <== sigR8x;
+    plaintext[5] <== sigR8y;
+    plaintext[6] <== sigS;
+
+    component enc = MACIMessageEncrypt();
+    enc.sharedKeyHash <== sharedKeyHash;
+    enc.nonce <== nonce;
+    for (var i = 0; i < 7; i++) {
+        enc.plaintext[i] <== plaintext[i];
+    }
+    for (var j = 0; j < 7; j++) {
+        ciphertext[j] <== enc.ciphertext[j];
+    }
+
+    component msgHash = MACIMessageHash();
+    for (var k = 0; k < 7; k++) {
+        msgHash.ciphertext[k] <== ciphertext[k];
+    }
+    messageHash <== msgHash.hash;
+}
+
+/**
+ * @title MACIVoteDecryptVerify
+ * @notice Coordinator-side: verify decrypted MACI vote option is valid for the poll.
+ * @dev Decrypt off-circuit (or via MACIMessageDecrypt), then prove voteOption in allowlist,
+ *      pollId matches, nonce >= minValidNonce. Unpacks p and checks field consistency.
+ * @param n Number of allowed vote options.
+ * @custom:input packed Decrypted command prefix p from plaintext[0].
+ * @custom:input voteOption, nonce, voteWeight, pollId, stateIndex — unpacked command fields.
+ * @custom:input expectedPollId Public poll id from contract.
+ * @custom:input minValidNonce Minimum valid nonce from ballot (blt_n + 1 in MACI).
+ * @custom:input allowedVoteOptions[n] Valid vote option indices.
+ * @custom:output valid 1 if all checks pass.
+ */
+template MACIVoteDecryptVerify(n) {
+    assert(n >= 1);
+    signal input packed;
+    signal input voteOption;
+    signal input nonce;
+    signal input voteWeight;
+    signal input pollId;
+    signal input stateIndex;
+    signal input expectedPollId;
+    signal input minValidNonce;
+    signal input allowedVoteOptions[n];
+    signal output valid;
+
+    component unpack = MACICommandUnpack();
+    unpack.packed <== packed;
+
+    component eqState = IsEqual();
+    eqState.in[0] <== unpack.stateIndex;
+    eqState.in[1] <== stateIndex;
+
+    component eqVote = IsEqual();
+    eqVote.in[0] <== unpack.voteOption;
+    eqVote.in[1] <== voteOption;
+
+    component eqNonce = IsEqual();
+    eqNonce.in[0] <== unpack.nonce;
+    eqNonce.in[1] <== nonce;
+
+    component eqWeight = IsEqual();
+    eqWeight.in[0] <== unpack.voteWeight;
+    eqWeight.in[1] <== voteWeight;
+
+    component eqPoll = IsEqual();
+    eqPoll.in[0] <== unpack.pollId;
+    eqPoll.in[1] <== pollId;
+
+    component eqExpectedPoll = IsEqual();
+    eqExpectedPoll.in[0] <== pollId;
+    eqExpectedPoll.in[1] <== expectedPollId;
+
+    component nonceOk = GreaterEqThan(50);
+    nonceOk.in[0] <== nonce;
+    nonceOk.in[1] <== minValidNonce;
+
+    component allowlist = VoteInAllowlist(n);
+    allowlist.vote <== voteOption;
+    for (var i = 0; i < n; i++) {
+        allowlist.allowedChoices[i] <== allowedVoteOptions[i];
+    }
+
+    component allOk = MultiAND(8);
+    allOk.in[0] <== eqState.out;
+    allOk.in[1] <== eqVote.out;
+    allOk.in[2] <== eqNonce.out;
+    allOk.in[3] <== eqWeight.out;
+    allOk.in[4] <== eqPoll.out;
+    allOk.in[5] <== eqExpectedPoll.out;
+    allOk.in[6] <== nonceOk.out;
+    allOk.in[7] <== allowlist.out;
+    valid <== allOk.out;
+}

--- a/index.js
+++ b/index.js
@@ -1,15 +1,14 @@
 "use strict";
 
-// opencircom — circuit library root.
-// Use in Circom via: include "opencircom/circuits/..." or add circuits to your include path.
-// This file is for JS tooling (e.g. resolving circuit paths).
-
 const path = require("path");
 
+const circuitsDir = path.join(__dirname, "circuits");
+
 module.exports = {
-    circuitsDir: path.join(__dirname, "circuits"),
+    circuitsDir,
     circuits: {
-        hashing: path.join(__dirname, "circuits", "hashing"),
-        merkle: path.join(__dirname, "circuits", "merkle"),
+        hashing: path.join(circuitsDir, "hashing"),
+        merkle: path.join(circuitsDir, "merkle"),
+        voting: path.join(circuitsDir, "voting"),
     },
 };

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.6.0",
   "description": "Reusable Circom ZK circuit templates — hashing, comparators, Merkle trees, and more. No dependency on circomlib.",
   "main": "index.js",
-  "files": ["circuits", "index.js"],
+  "bin": {
+    "opencircom": "bin/opencircom.js"
+  },
+  "files": ["circuits", "index.js", "bin"],
   "scripts": {
     "setup:zk": "bash scripts/setup_zk_tests.sh",
-    "test": "npm run setup:zk && mocha test/*.js --timeout 120000",
     "compile:test": "bash scripts/compile_test_circuits.sh",
+    "test": "npm run compile:test && npm run setup:zk && mocha test/*.js --timeout 120000",
     "docs": "node scripts/gen_docs.js"
   },
   "keywords": ["circom", "zk", "zero-knowledge", "snark", "poseidon", "merkle", "circuit"],

--- a/scripts/compile_test_circuits.sh
+++ b/scripts/compile_test_circuits.sh
@@ -1,62 +1,22 @@
 #!/bin/bash
+# Compile every test wrapper circuit under test/circuits/ (skips missing files).
 set -e
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 mkdir -p build
+
+if ! command -v circom >/dev/null 2>&1; then
+  echo "Error: circom not found on PATH. Install circom 2.x first."
+  exit 1
+fi
+
 echo "Compiling test circuits (opencircom)..."
-circom test/circuits/poseidon_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/comparators_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon_public_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/merkle_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/gates_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/bitify_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/mimc_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/comparators_ext_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/switcher_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/mux_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/nullifier_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon4_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/voting_commit_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/voting_reveal_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/sha256_256_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon_merkle_helper.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/sparse_merkle_inclusion_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/sparse_merkle_exclusion_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/incremental_merkle_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/merkle_update_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/strict_num2bits_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/range_proof_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/arithmetic_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/muxn_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/divrem_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/utils_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/exp_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/assert_not_equal_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/index_of_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/minmax_allequal_count_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/minn_maxn_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/tally_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/allowlist_membership_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/pad_bits_10star_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/conditional_select_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/balance_proof_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/vote_in_allowlist_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/pad_pkcs7_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/vote_commit_allowlist_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poe_verify_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon1_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon_encrypt_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/identity_commitment_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/semaphore_membership_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/accumulator_membership_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/utf8_validation_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/fixed_string_match_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/bytes_all_in_range_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon2_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon3_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/poseidon7_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/maci_command_pack_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/maci_message_roundtrip_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/maci_vote_commit_test.circom --r1cs --wasm -o build -l circuits
-circom test/circuits/maci_vote_decrypt_verify_test.circom --r1cs --wasm -o build -l circuits
-echo "Done."
+count=0
+for f in "$ROOT"/test/circuits/*.circom; do
+  [ -f "$f" ] || continue
+  name="$(basename "$f")"
+  echo "  $name"
+  circom "$f" --r1cs --wasm -o build -l circuits
+  count=$((count + 1))
+done
+echo "Done. Compiled $count circuit(s)."

--- a/scripts/compile_test_circuits.sh
+++ b/scripts/compile_test_circuits.sh
@@ -52,4 +52,11 @@ circom test/circuits/accumulator_membership_test.circom --r1cs --wasm -o build -
 circom test/circuits/utf8_validation_test.circom --r1cs --wasm -o build -l circuits
 circom test/circuits/fixed_string_match_test.circom --r1cs --wasm -o build -l circuits
 circom test/circuits/bytes_all_in_range_test.circom --r1cs --wasm -o build -l circuits
+circom test/circuits/poseidon2_test.circom --r1cs --wasm -o build -l circuits
+circom test/circuits/poseidon3_test.circom --r1cs --wasm -o build -l circuits
+circom test/circuits/poseidon7_test.circom --r1cs --wasm -o build -l circuits
+circom test/circuits/maci_command_pack_test.circom --r1cs --wasm -o build -l circuits
+circom test/circuits/maci_message_roundtrip_test.circom --r1cs --wasm -o build -l circuits
+circom test/circuits/maci_vote_commit_test.circom --r1cs --wasm -o build -l circuits
+circom test/circuits/maci_vote_decrypt_verify_test.circom --r1cs --wasm -o build -l circuits
 echo "Done."

--- a/test/circuits/maci_command_pack_test.circom
+++ b/test/circuits/maci_command_pack_test.circom
@@ -1,0 +1,22 @@
+pragma circom 2.0.0;
+
+include "../../circuits/voting/maci_voting.circom";
+
+template MACICommandPackTest() {
+    signal input stateIndex;
+    signal input voteOption;
+    signal input nonce;
+    signal input voteWeight;
+    signal input pollId;
+    signal output packed;
+
+    component p = MACICommandPack();
+    p.stateIndex <== stateIndex;
+    p.voteOption <== voteOption;
+    p.nonce <== nonce;
+    p.voteWeight <== voteWeight;
+    p.pollId <== pollId;
+    packed <== p.packed;
+}
+
+component main = MACICommandPackTest();

--- a/test/circuits/maci_message_roundtrip_test.circom
+++ b/test/circuits/maci_message_roundtrip_test.circom
@@ -1,0 +1,30 @@
+pragma circom 2.0.0;
+
+include "../../circuits/voting/maci_voting.circom";
+
+template MACIMessageRoundtripTest() {
+    signal input sharedKeyHash;
+    signal input nonce;
+    signal input plaintext[7];
+    signal input expectedPlaintext[7];
+
+    component enc = MACIMessageEncrypt();
+    enc.sharedKeyHash <== sharedKeyHash;
+    enc.nonce <== nonce;
+    for (var i = 0; i < 7; i++) {
+        enc.plaintext[i] <== plaintext[i];
+    }
+
+    component dec = MACIMessageDecrypt();
+    dec.sharedKeyHash <== sharedKeyHash;
+    dec.nonce <== nonce;
+    for (var j = 0; j < 7; j++) {
+        dec.ciphertext[j] <== enc.ciphertext[j];
+    }
+
+    for (var k = 0; k < 7; k++) {
+        dec.plaintext[k] === expectedPlaintext[k];
+    }
+}
+
+component main = MACIMessageRoundtripTest();

--- a/test/circuits/maci_vote_commit_test.circom
+++ b/test/circuits/maci_vote_commit_test.circom
@@ -1,0 +1,40 @@
+pragma circom 2.0.0;
+
+include "../../circuits/voting/maci_voting.circom";
+
+template MACIVoteCommitTest() {
+    signal input stateIndex;
+    signal input voteOption;
+    signal input nonce;
+    signal input voteWeight;
+    signal input pollId;
+    signal input pubKeyX;
+    signal input pubKeyY;
+    signal input salt;
+    signal input sigR8x;
+    signal input sigR8y;
+    signal input sigS;
+    signal input sharedKeyHash;
+
+    signal input messageHash;
+    signal input commandHash;
+
+    component c = MACIVoteCommit();
+    c.stateIndex <== stateIndex;
+    c.voteOption <== voteOption;
+    c.nonce <== nonce;
+    c.voteWeight <== voteWeight;
+    c.pollId <== pollId;
+    c.pubKeyX <== pubKeyX;
+    c.pubKeyY <== pubKeyY;
+    c.salt <== salt;
+    c.sigR8x <== sigR8x;
+    c.sigR8y <== sigR8y;
+    c.sigS <== sigS;
+    c.sharedKeyHash <== sharedKeyHash;
+
+    c.messageHash === messageHash;
+    c.commandHash === commandHash;
+}
+
+component main {public [messageHash, commandHash]} = MACIVoteCommitTest();

--- a/test/circuits/maci_vote_decrypt_verify_test.circom
+++ b/test/circuits/maci_vote_decrypt_verify_test.circom
@@ -1,0 +1,32 @@
+pragma circom 2.0.0;
+
+include "../../circuits/voting/maci_voting.circom";
+
+template MACIVoteDecryptVerifyTest() {
+    signal input packed;
+    signal input voteOption;
+    signal input nonce;
+    signal input voteWeight;
+    signal input pollId;
+    signal input stateIndex;
+    signal input expectedPollId;
+    signal input minValidNonce;
+    signal input allowedVoteOptions[3];
+    signal output valid;
+
+    component v = MACIVoteDecryptVerify(3);
+    v.packed <== packed;
+    v.voteOption <== voteOption;
+    v.nonce <== nonce;
+    v.voteWeight <== voteWeight;
+    v.pollId <== pollId;
+    v.stateIndex <== stateIndex;
+    v.expectedPollId <== expectedPollId;
+    v.minValidNonce <== minValidNonce;
+    for (var i = 0; i < 3; i++) {
+        v.allowedVoteOptions[i] <== allowedVoteOptions[i];
+    }
+    valid <== v.valid;
+}
+
+component main {public [expectedPollId, minValidNonce]} = MACIVoteDecryptVerifyTest();

--- a/test/circuits/poseidon2_test.circom
+++ b/test/circuits/poseidon2_test.circom
@@ -1,0 +1,14 @@
+pragma circom 2.0.0;
+
+include "../../circuits/hashing/poseidon.circom";
+
+template Poseidon2Test() {
+    signal input in[2];
+    signal output out;
+    component p = Poseidon(2);
+    p.inputs[0] <== in[0];
+    p.inputs[1] <== in[1];
+    out <== p.out;
+}
+
+component main = Poseidon2Test();

--- a/test/circuits/poseidon3_test.circom
+++ b/test/circuits/poseidon3_test.circom
@@ -1,0 +1,15 @@
+pragma circom 2.0.0;
+
+include "../../circuits/hashing/poseidon.circom";
+
+template Poseidon3Test() {
+    signal input in[3];
+    signal output out;
+    component p = Poseidon(3);
+    for (var i = 0; i < 3; i++) {
+        p.inputs[i] <== in[i];
+    }
+    out <== p.out;
+}
+
+component main = Poseidon3Test();

--- a/test/circuits/poseidon7_test.circom
+++ b/test/circuits/poseidon7_test.circom
@@ -1,0 +1,15 @@
+pragma circom 2.0.0;
+
+include "../../circuits/hashing/poseidon.circom";
+
+template Poseidon7Test() {
+    signal input in[7];
+    signal output out;
+    component p = Poseidon(7);
+    for (var i = 0; i < 7; i++) {
+        p.inputs[i] <== in[i];
+    }
+    out <== p.out;
+}
+
+component main = Poseidon7Test();

--- a/test/maci_voting_test.js
+++ b/test/maci_voting_test.js
@@ -1,0 +1,320 @@
+const chai = require("chai");
+const path = require("path");
+const wasm_tester = require("circom_tester").wasm;
+
+const assert = chai.assert;
+const BUILD = path.join(__dirname, "..", "build");
+
+async function poseidonN(circuit, inputs) {
+  const w = await circuit.calculateWitness({ in: inputs }, true);
+  await circuit.checkConstraints(w);
+  return w[1].toString();
+}
+
+async function poseidon2(circuit, a, b) {
+  return poseidonN(circuit, [a, b]);
+}
+
+async function poseidon3(circuit, a, b, c) {
+  return poseidonN(circuit, [a, b, c]);
+}
+
+async function poseidon4(circuit, a, b, c, d) {
+  return poseidonN(circuit, [a, b, c, d]);
+}
+
+async function poseidon7(circuit, arr) {
+  return poseidonN(circuit, arr);
+}
+
+function maciPack(stateIndex, voteOption, nonce, voteWeight, pollId) {
+  const pow50 = 2n ** 50n;
+  const pow100 = pow50 * pow50;
+  const pow150 = pow100 * pow50;
+  const pow200 = pow150 * pow50;
+  return (
+    BigInt(stateIndex) +
+    BigInt(voteOption) * pow50 +
+    BigInt(nonce) * pow100 +
+    BigInt(voteWeight) * pow150 +
+    BigInt(pollId) * pow200
+  ).toString();
+}
+
+async function maciKeystream(poseidon3Circuit, sharedKeyHash, nonce, index) {
+  return poseidon3(poseidon3Circuit, sharedKeyHash, nonce, index);
+}
+
+async function maciEncrypt(poseidon3Circuit, sharedKeyHash, nonce, plaintext) {
+  const ciphertext = [];
+  for (let i = 0; i < plaintext.length; i++) {
+    const ks = await maciKeystream(poseidon3Circuit, sharedKeyHash, nonce, i);
+    const pt = BigInt(plaintext[i]);
+    const ct = (pt + BigInt(ks)).toString();
+    ciphertext.push(ct);
+  }
+  return ciphertext;
+}
+
+describe("MACI vote building blocks (opencircom)", function () {
+  let packCircuit;
+  let commitCircuit;
+  let decryptVerifyCircuit;
+  let roundtripCircuit;
+  let poseidon2Circuit;
+  let poseidon3Circuit;
+  let poseidon4Circuit;
+  let poseidon7Circuit;
+  this.timeout(120000);
+
+  before(async () => {
+    const opts = { output: BUILD, recompile: false };
+    packCircuit = await wasm_tester(
+      path.join(__dirname, "circuits", "maci_command_pack_test.circom"),
+      opts
+    );
+    commitCircuit = await wasm_tester(
+      path.join(__dirname, "circuits", "maci_vote_commit_test.circom"),
+      opts
+    );
+    decryptVerifyCircuit = await wasm_tester(
+      path.join(__dirname, "circuits", "maci_vote_decrypt_verify_test.circom"),
+      opts
+    );
+    roundtripCircuit = await wasm_tester(
+      path.join(__dirname, "circuits", "maci_message_roundtrip_test.circom"),
+      opts
+    );
+    poseidon2Circuit = await wasm_tester(
+      path.join(__dirname, "circuits", "poseidon2_test.circom"),
+      opts
+    );
+    poseidon3Circuit = await wasm_tester(
+      path.join(__dirname, "circuits", "poseidon3_test.circom"),
+      opts
+    );
+    poseidon4Circuit = await wasm_tester(
+      path.join(__dirname, "circuits", "poseidon4_test.circom"),
+      opts
+    );
+    poseidon7Circuit = await wasm_tester(
+      path.join(__dirname, "circuits", "poseidon7_test.circom"),
+      opts
+    );
+  });
+
+  describe("MACICommandPack", function () {
+    it("packs five 50-bit fields into p", async () => {
+      const stateIndex = 3;
+      const voteOption = 1;
+      const nonce = 2;
+      const voteWeight = 10;
+      const pollId = 99;
+      const expected = maciPack(stateIndex, voteOption, nonce, voteWeight, pollId);
+      const w = await packCircuit.calculateWitness(
+        { stateIndex, voteOption, nonce, voteWeight, pollId },
+        true
+      );
+      await packCircuit.checkConstraints(w);
+      assert.equal(w[1].toString(), expected);
+    });
+  });
+
+  describe("MACIMessageEncrypt / Decrypt", function () {
+    it("encrypt-decrypt roundtrip restores plaintext", async () => {
+      const sharedKeyHash = await poseidon2(poseidon2Circuit, 111, 222);
+      const nonce = 2;
+      const plaintext = ["100", "200", "300", "400", "500", "600", "700"];
+      const w = await roundtripCircuit.calculateWitness(
+        { sharedKeyHash, nonce, plaintext, expectedPlaintext: plaintext },
+        true
+      );
+      await roundtripCircuit.checkConstraints(w);
+    });
+  });
+
+  describe("MACIVoteCommit", function () {
+    it("commit: ciphertext and hashes match expected", async () => {
+      const stateIndex = 1;
+      const voteOption = 2;
+      const nonce = 1;
+      const voteWeight = 5;
+      const pollId = 42;
+      const pubKeyX = 123456789;
+      const pubKeyY = 987654321;
+      const salt = 555;
+      const sigR8x = 1111;
+      const sigR8y = 2222;
+      const sigS = 3333;
+      const ks0 = 9001;
+      const ks1 = 9002;
+      const sharedKeyHash = await poseidon2(poseidon2Circuit, ks0, ks1);
+
+      const packed = maciPack(stateIndex, voteOption, nonce, voteWeight, pollId);
+      const commandHash = await poseidon4(
+        poseidon4Circuit,
+        packed,
+        pubKeyX,
+        pubKeyY,
+        salt
+      );
+      const plaintext = [packed, pubKeyX, pubKeyY, salt, sigR8x, sigR8y, sigS];
+      const ciphertext = await maciEncrypt(
+        poseidon3Circuit,
+        sharedKeyHash,
+        nonce,
+        plaintext
+      );
+      const messageHash = await poseidon7(poseidon7Circuit, ciphertext);
+
+      const w = await commitCircuit.calculateWitness(
+        {
+          stateIndex,
+          voteOption,
+          nonce,
+          voteWeight,
+          pollId,
+          pubKeyX,
+          pubKeyY,
+          salt,
+          sigR8x,
+          sigR8y,
+          sigS,
+          sharedKeyHash,
+          messageHash,
+          commandHash,
+        },
+        true
+      );
+      await commitCircuit.checkConstraints(w);
+    });
+
+    it("fails when messageHash does not match ciphertext", async () => {
+      const inputs = {
+        stateIndex: 1,
+        voteOption: 0,
+        nonce: 1,
+        voteWeight: 1,
+        pollId: 1,
+        pubKeyX: 1,
+        pubKeyY: 2,
+        salt: 3,
+        sigR8x: 4,
+        sigR8y: 5,
+        sigS: 6,
+        sharedKeyHash: 7,
+        messageHash: "0",
+        commandHash: "0",
+      };
+      try {
+        await commitCircuit.calculateWitness(inputs, true);
+        assert.fail("should have thrown");
+      } catch (e) {
+        assert.isOk(e);
+      }
+    });
+  });
+
+  describe("MACIVoteDecryptVerify", function () {
+    it("valid decrypted vote passes allowlist and nonce checks", async () => {
+      const stateIndex = 5;
+      const voteOption = 2;
+      const nonce = 3;
+      const voteWeight = 10;
+      const pollId = 99;
+      const packed = maciPack(stateIndex, voteOption, nonce, voteWeight, pollId);
+      const allowedVoteOptions = [0, 2, 5];
+      const w = await decryptVerifyCircuit.calculateWitness(
+        {
+          packed,
+          voteOption,
+          nonce,
+          voteWeight,
+          pollId,
+          stateIndex,
+          expectedPollId: pollId,
+          minValidNonce: 2,
+          allowedVoteOptions,
+        },
+        true
+      );
+      await decryptVerifyCircuit.checkConstraints(w);
+      assert.equal(w[1].toString(), "1");
+    });
+
+    it("fails when voteOption not in allowlist", async () => {
+      const stateIndex = 1;
+      const voteOption = 7;
+      const nonce = 2;
+      const voteWeight = 1;
+      const pollId = 1;
+      const packed = maciPack(stateIndex, voteOption, nonce, voteWeight, pollId);
+      const w = await decryptVerifyCircuit.calculateWitness(
+        {
+          packed,
+          voteOption,
+          nonce,
+          voteWeight,
+          pollId,
+          stateIndex,
+          expectedPollId: pollId,
+          minValidNonce: 1,
+          allowedVoteOptions: [0, 2, 5],
+        },
+        true
+      );
+      await decryptVerifyCircuit.checkConstraints(w);
+      assert.equal(w[1].toString(), "0");
+    });
+
+    it("fails when nonce below minValidNonce", async () => {
+      const stateIndex = 1;
+      const voteOption = 2;
+      const nonce = 1;
+      const voteWeight = 1;
+      const pollId = 10;
+      const packed = maciPack(stateIndex, voteOption, nonce, voteWeight, pollId);
+      const w = await decryptVerifyCircuit.calculateWitness(
+        {
+          packed,
+          voteOption,
+          nonce,
+          voteWeight,
+          pollId,
+          stateIndex,
+          expectedPollId: pollId,
+          minValidNonce: 2,
+          allowedVoteOptions: [0, 2, 5],
+        },
+        true
+      );
+      await decryptVerifyCircuit.checkConstraints(w);
+      assert.equal(w[1].toString(), "0");
+    });
+
+    it("fails when pollId mismatch", async () => {
+      const stateIndex = 1;
+      const voteOption = 2;
+      const nonce = 2;
+      const voteWeight = 1;
+      const pollId = 10;
+      const packed = maciPack(stateIndex, voteOption, nonce, voteWeight, pollId);
+      const w = await decryptVerifyCircuit.calculateWitness(
+        {
+          packed,
+          voteOption,
+          nonce,
+          voteWeight,
+          pollId,
+          stateIndex,
+          expectedPollId: 99,
+          minValidNonce: 1,
+          allowedVoteOptions: [0, 2, 5],
+        },
+        true
+      );
+      await decryptVerifyCircuit.checkConstraints(w);
+      assert.equal(w[1].toString(), "0");
+    });
+  });
+});

--- a/test/sha256_test.js
+++ b/test/sha256_test.js
@@ -27,13 +27,15 @@ function bits2buffer(bits) {
     return Buffer.from(bytes);
 }
 
+const BUILD = path.join(__dirname, "..", "build");
+
 describe("SHA-256 (opencircom)", function () {
     let circuit256;
     this.timeout(120000);
 
     before(async () => {
         circuit256 = await wasm_tester(path.join(__dirname, "circuits", "sha256_256_test.circom"), {
-            output: path.join(__dirname, "build"),
+            output: BUILD,
             recompile: false
         });
     });


### PR DESCRIPTION
## Summary
- Add MACI v1 composable vote circuits (`MACIVoteCommit`, `MACIVoteDecryptVerify`, command pack/hash, message encrypt/decrypt) — closes #23
- Add `opencircom` CLI (`path`, `compile`, `list`, `init`) — closes #14
- Fix test build pipeline so `npm test` compiles all wrappers before running mocha

## MACI circuits (#23)
New templates in `circuits/voting/maci_voting.circom`:
- `MACICommandPack` / `MACICommandUnpack` — 5×50-bit field packing per [MACI v1 spec](https://maci.pse.dev/docs/v1.2/spec)
- `MACICommandHash` — `h_cm = poseidon4([p, pubKeyX, pubKeyY, salt])`
- `MACISharedKeyHash`, `MACIMessageEncrypt`, `MACIMessageDecrypt`, `MACIMessageHash`
- `MACIVoteCommit` — encrypt command+signature plaintext
- `MACIVoteDecryptVerify(n)` — allowlist + pollId + nonce checks via `VoteInAllowlist`

EdDSA, ECDH, and DuplexSponge encryption remain off-circuit (documented in SECURITY.md).

## CLI (#14)
```bash
npx opencircom path
npx opencircom compile circuits/MyCircuit.circom -o build
npx opencircom compile --all-test
npx opencircom list
npx opencircom init my_circuit