### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18.x
+          - 20.x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Circom
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/circom
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: circom-v2.2.3-${{ runner.os }}
+
+      - name: Install Circom
+        run: |
+          if ! command -v circom >/dev/null 2>&1; then
+            cargo install --locked --git https://github.com/iden3/circom.git --tag v2.2.3 circom
+          fi
+          circom --version
+
+      - name: Install system tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xxd
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache ZK test artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/pot12_final.ptau
+            build/poseidon_public_test_0000.zkey
+            build/poseidon_public_test_final.zkey
+            build/poseidon_public_test_vkey.json
+          key: zk-test-artifacts-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('test/circuits/poseidon_public_test.circom', 'scripts/setup_zk_tests.sh') }}
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Circom](https://img.shields.io/badge/Circom-ZK%20Circuits-8B5CF6)](https://docs.circom.io/)
-[![Tests](https://img.shields.io/badge/tests-153%2B%20passing-success)](./test)
+[![Tests](https://github.com/jose-compu/opencircom/actions/workflows/test.yml/badge.svg)](https://github.com/jose-compu/opencircom/actions/workflows/test.yml)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.x-brightgreen)](https://nodejs.org/)
 [![No circomlib](https://img.shields.io/badge/deps-no%20circomlib-informational)](./circuits)
 


### PR DESCRIPTION
Fixes jose-compu/opencircom#17.

## Summary

- Adds `.github/workflows/test.yml` for push-to-main and pull request CI.
- Runs the existing `npm test` command on Node.js 18.x and 20.x.
- Installs a pinned Circom release (`v2.2.3`) before running tests.
- Caches npm packages through `actions/setup-node` and caches the generated test ZK artifacts used by `scripts/setup_zk_tests.sh`.
- Replaces the static README test badge with the dynamic GitHub Actions badge.

## Validation

- `git diff --cached --check`

I did not run the full local `npm test` in this workspace because `circom` is not installed locally. The workflow installs Circom in CI before running the repository's existing test command.

## Bounty / payout

This addresses the low-severity CI/documentation improvement requested in opencircom#17. If accepted under the PayPal-compatible bounty program in opencircom#1, PayPal works here:
https://paypal.me/ShaimaaElkadi
