### PR TITLE
Add AgeThresholdProof template built on RangeProof

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,13 @@
 
 - `Nullifier(secret, externalNullifier)` is for one-time use per (`secret`, externalNullifier). Use a unique `externalNullifier` per action (e.g. poll id, withdrawal nonce).
 
+### AgeThresholdProof
+
+- **currentYear trust**: `currentYear` must come from a trusted source (e.g. `block.timestamp` in a smart contract, or a verified oracle). If `currentYear` is prover-supplied (private signal), the prover can forge a valid proof for any `birthYear` — age verification becomes meaningless.
+- **minAge**: This signal is intentionally not range-checked (typically a small public constant like 18 or 21). A large `minAge > 2^n` causes the circuit to always output 0, which is a safe failure.
+- **Underflow protection**: `birthYear > currentYear` produces a field-underflow caught by `StrictNum2Bits` on the intermediate `age` signal. The prover cannot exploit this to produce a false positive.
+- **Bit width**: Choose `n` large enough for your application's year range (e.g. `n=32` covers years up to ~2106). Too small an `n` truncates years and may produce false positives.
+
 ### MACI building blocks
 
 - **Off-circuit coordinator**: Baby JubJub ECDH shared key, EdDSA sign `h_cm`, full MACI DuplexSponge encryption, message batch processing, and state/ballot tree updates remain application-layer ([MACI v1 spec](https://maci.pse.dev/docs/v1.2/spec)).

--- a/circuits/comparators.circom
+++ b/circuits/comparators.circom
@@ -210,6 +210,9 @@ template AgeThresholdProof(n) {
     component snbAge = StrictNum2Bits(n);
     snbAge.in <== age;
 
+    component snbMinAge = StrictNum2Bits(n);
+    snbMinAge.in <== minAge;
+
     component geq = GreaterEqThan(n);
     geq.in[0] <== age;
     geq.in[1] <== minAge;

--- a/circuits/comparators.circom
+++ b/circuits/comparators.circom
@@ -172,3 +172,46 @@ template RangeProof(n) {
     leq.out === 1;
     out <== 1;
 }
+
+/**
+ * @title AgeThresholdProof
+ * @notice Proves currentYear - birthYear >= minAge without revealing birthYear.
+ * @dev Uses StrictNum2Bits to enforce year ranges; GreaterEqThan for age comparison.
+ *      The intermediate signal `age` is also StrictNum2Bits-checked, which catches
+ *      underflow when birthYear > currentYear. minAge is not range-checked (typically
+ *      a small public constant like 18 or 21).
+ * @param n Bit width for years (must be ≤ 251 and ≥ ceil(log2(currentYear+1))).
+ *          Use n=32 for years up to ~2106.
+ * @custom:input birthYear Private birth year.
+ * @custom:input currentYear Current year (public when sourced from chain timestamp or oracle).
+ * @custom:input minAge Minimum age threshold (public, e.g. 18).
+ * @custom:output valid 1 if currentYear - birthYear >= minAge, else 0.
+ * @custom:complexity 3×StrictNum2Bits(n) + 1×GreaterEqThan(n): ~3n + n + 2 constraints ≡ O(n).
+ * @custom:security If currentYear is prover-supplied (private), the prover can forge a valid
+ *                  proof for any birthYear. Always source currentYear from a trusted context
+ *                  (e.g. block.timestamp in a smart contract). See SECURITY.md for details.
+ */
+template AgeThresholdProof(n) {
+    assert(n <= 251);
+    signal input birthYear;
+    signal input currentYear;
+    signal input minAge;
+    signal output valid;
+
+    component snbBirth = StrictNum2Bits(n);
+    snbBirth.in <== birthYear;
+
+    component snbCurrent = StrictNum2Bits(n);
+    snbCurrent.in <== currentYear;
+
+    signal age;
+    age <== currentYear - birthYear;
+
+    component snbAge = StrictNum2Bits(n);
+    snbAge.in <== age;
+
+    component geq = GreaterEqThan(n);
+    geq.in[0] <== age;
+    geq.in[1] <== minAge;
+    valid <== geq.out;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,17 @@
       "name": "opencircom",
       "version": "0.7.0",
       "license": "MIT",
+      "bin": {
+        "opencircom": "bin/opencircom.js"
+      },
       "devDependencies": {
         "chai": "^4.3.10",
         "circom_tester": "^0.0.21",
         "mocha": "^10.7.3",
         "snarkjs": "^0.7.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@iden3/bigarray": {

--- a/test/age_threshold_proof_test.js
+++ b/test/age_threshold_proof_test.js
@@ -1,0 +1,41 @@
+const chai = require("chai");
+const path = require("path");
+const wasm_tester = require("circom_tester").wasm;
+
+const assert = chai.assert;
+
+const BUILD = path.join(__dirname, "..", "build");
+
+describe("AgeThresholdProof (opencircom)", function () {
+    let circuit;
+    this.timeout(60000);
+
+    before(async () => {
+        circuit = await wasm_tester(
+            path.join(__dirname, "circuits", "age_threshold_proof_test.circom"),
+            { output: BUILD, recompile: false }
+        );
+    });
+
+    it("accepts age == minAge (boundary: exactly passes)", async () => {
+        const w = await circuit.calculateWitness({ birthYear: 2000, currentYear: 2026, minAge: 26 }, true);
+        await circuit.checkConstraints(w);
+        assert.equal(w[1].toString(), "1");
+    });
+
+    it("rejects age == minAge - 1 (boundary: one year below)", async () => {
+        const w = await circuit.calculateWitness({ birthYear: 2001, currentYear: 2026, minAge: 26 }, true);
+        await circuit.checkConstraints(w);
+        assert.equal(w[1].toString(), "0");
+    });
+
+    it("rejects birthYear > currentYear (underflow)", async () => {
+        try {
+            const w = await circuit.calculateWitness({ birthYear: 2030, currentYear: 2026, minAge: 18 }, true);
+            await circuit.checkConstraints(w);
+            assert.fail("should have thrown for birthYear > currentYear");
+        } catch (e) {
+            assert.ok(e, "expected constraint failure");
+        }
+    });
+});

--- a/test/circuits/age_threshold_proof_test.circom
+++ b/test/circuits/age_threshold_proof_test.circom
@@ -1,0 +1,17 @@
+pragma circom 2.0.0;
+
+include "../../circuits/comparators.circom";
+
+template AgeThresholdProofTest() {
+    signal input birthYear;
+    signal input currentYear;
+    signal input minAge;
+    signal output valid;
+    component atp = AgeThresholdProof(32);
+    atp.birthYear <== birthYear;
+    atp.currentYear <== currentYear;
+    atp.minAge <== minAge;
+    valid <== atp.valid;
+}
+
+component main = AgeThresholdProofTest();


### PR DESCRIPTION
## Summary
Adds a dedicated `AgeThresholdProof(n)` template that proves `currentYear - birthYear >= minAge` without revealing `birthYear`.

## Changes
- **`circuits/comparators.circom`** — Added `AgeThresholdProof(n)` template using `StrictNum2Bits(n)` for input range enforcement and `GreaterEqThan(n)` for age comparison
- **`test/circuits/age_threshold_proof_test.circom`** — Test wrapper with `n=32`
- **`test/age_threshold_proof_test.js`** — 3 test cases:
  - `age == minAge` → `valid=1` (boundary pass)
  - `age == minAge-1` → `valid=0` (boundary fail)
  - `birthYear > currentYear` → constraint error (underflow)
- **`SECURITY.md`** — Added guidance on `currentYear` trust model, underflow protection, and bit width selection

Closes #11
