### PR TITLE
Release v0.8.0: Safe wrappers for binary-constrained building blocks (#15)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.0
+
+- Safe wrappers for binary-constrained building blocks (#15): `SafeAND()`, `SafeOR()`, `SafeMux1()`, `SafeMux2()`, `SafeBits2Num(n)` — enforce 0/1 on gate inputs, mux selectors, and bit arrays.
+- Raw `AND`/`OR`/`Mux1`/`Mux2`/`Bits2Num` marked building-block-only in docs; prefer Safe* for untrusted inputs.
+- Tests: functional + rejection cases for non-binary inputs (10 new tests).
+- Docs: README circuit table, SECURITY.md Safe* guidance, regenerated documentation.html.
+
 ## 0.7.0
 
 - MACI v1 building blocks: `MACICommandPack`, `MACICommandUnpack`, `MACICommandHash`, `MACISharedKeyHash`, `MACIMessageEncrypt`, `MACIMessageDecrypt`, `MACIMessageHash`, `MACIVoteCommit`, `MACIVoteDecryptVerify(n)` — command packing/h_cm per [MACI v1 spec](https://maci.pse.dev/docs/v1.2/spec); additive Poseidon keystream encryption; coordinator verify with allowlist + nonce. 8 tests.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Circom](https://img.shields.io/badge/Circom-ZK%20Circuits-8B5CF6)](https://docs.circom.io/)
-[![Tests](https://img.shields.io/badge/tests-153%2B%20passing-success)](./test)
+[![Tests](https://img.shields.io/badge/tests-163%2B%20passing-success)](./test)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.x-brightgreen)](https://nodejs.org/)
 [![No circomlib](https://img.shields.io/badge/deps-no%20circomlib-informational)](./circuits)
 
@@ -54,7 +54,7 @@ From npm:
 npm install opencircom
 ```
 
-Or add to your `package.json`: `"opencircom": "^0.7.0"`.
+Or add to your `package.json`: `"opencircom": "^0.8.0"`.
 
 ### Hardhat
 
@@ -110,9 +110,9 @@ Output markdown is written to **docs/api/**; the HTML documentation page at **do
 | Comparators | `LessThan(n)`, `GreaterThan(n)`, `IsEqual()`, `IsZero()`, `AssertNotEqual()` | Range, equality, aliasing-safe (force a ≠ b). |
 | Comparators | `StrictNum2Bits(n)` | Num2Bits with in ∈ [0, 2^n−1] enforced. |
 | Comparators | `RangeProof(n)` | Prove a ≤ x ≤ b (inputs x, a, b; n-bit range). |
-| Bitify    | `Num2Bits(n)`, `Bits2Num(n)` | Bit decomposition (see also `compconstant.circom`, `aliascheck.circom`). |
-| Gates     | `AND`, `OR`, `NOT`, `XOR`, `MultiAND(n)` | Boolean gates. |
-| Utils     | `Mux1`, `Mux2`, `MuxN` / `SelectByIndex(N, nBits)`, `Switcher` | Multiplexer and conditional swap; N-way select by index. |
+| Bitify    | `Num2Bits(n)`, `Bits2Num(n)`, `SafeBits2Num(n)` | Bit decomposition; `SafeBits2Num` binary-constrains each bit (prefer for untrusted inputs). |
+| Gates     | `AND`, `OR`, `SafeAND`, `SafeOR`, `NOT`, `XOR`, `MultiAND(n)` | Boolean gates; `SafeAND`/`SafeOR` binary-constrain inputs. |
+| Utils     | `Mux1`, `Mux2`, `SafeMux1`, `SafeMux2`, `MuxN` / `SelectByIndex(N, nBits)`, `Switcher` | Multiplexer and conditional swap; Safe* muxes constrain selectors to {0,1}. |
 | Arithmetic | `Sum(n)`, `InnerProduct(n)`, `DivRem(n)`, `ExpByBits(n)` | Sum, dot product; safe div/rem; field exponentiation (exp as bits). |
 | Utils      | `PadBits(n, target)`, `OneOfN(n)`, `IndexOf(N, nBits)` | Zero-pad bits; 1 if value in array; prove index where arr[i]==value. |
 | Utils      | `Min2(n)`, `Max2(n)` | Minimum / maximum of two n-bit values. |
@@ -161,17 +161,18 @@ Planned or community-requested; not yet implemented:
 - **Set membership**: Accumulator-based membership implemented (`AccumulatorMembership(n)`, uses PoEVerify). Merkle/sparse already done.
 - **Payments**: Confidential transfer and mixer (deposit/withdraw) deferred to application repos; build with Merkle, Nullifier, BalanceProof from this lib.
 - **String & data**: UTF-8 validation and simple fixed/range patterns implemented; full regex and JSON field extraction deferred.
-- **Utilities**: Other padding or encoding schemes (e.g. ISO padding, length-prefix, base64 in-circuit) deferred; PadBits, PadBits10Star, PadPKCS7 remain.
+- **Utilities**: Other padding or encoding schemes (e.g. ISO padding, length-prefix, base64 in-circuit) deferred; PadBits, PadBits10Star, PadPKCS7 remain. Safe wrappers for gates/mux/Bits2Num implemented (`SafeAND`, `SafeOR`, `SafeMux1`, `SafeMux2`, `SafeBits2Num`).
 
 Contributions welcome; open an issue to propose or prioritize.
 
 ## Security
 
 - **Range checks**: Use `StrictNum2Bits(n)` or `RangeProof(n)` for untrusted inputs; `LessThan(n)` assumes inputs &lt; 2^n.
+- **Binary selectors / bits**: Prefer `SafeAND`, `SafeOR`, `SafeMux1`, `SafeMux2`, `SafeBits2Num(n)` when inputs may be untrusted. Raw `AND`/`OR`/`Mux1`/`Mux2`/`Bits2Num` are building blocks and do not binary-constrain inputs.
 - **Merkle**: `pathIndices[i]` are constrained binary in-circuit; `Switcher` constrains `sel` to {0,1}.
 - **Nullifier**: Use a unique `externalNullifier` per action to avoid cross-action replay.
 - **Hashing**: Poseidon uses standard Hades parameters (same as circomlib); constants in `circuits/hashing/poseidon_constants.circom`.
-- **Audit**: An internal security audit (0.5.0) fixed binary constraints and range checks in Switcher, ForceEqualIfEnabled, IncrementalMerkleInclusion, DivRem, and PadPKCS7. See [CHANGELOG](CHANGELOG) for details.
+- **Audit**: An internal security audit (0.5.0) fixed binary constraints and range checks in Switcher, ForceEqualIfEnabled, IncrementalMerkleInclusion, DivRem, and PadPKCS7. Safe* wrappers added in 0.8.0. See [CHANGELOG](CHANGELOG) for details.
 
 See [SECURITY.md](SECURITY.md) for more.
 
@@ -204,7 +205,7 @@ From this repo, `npm run compile:test` compiles every file in `test/circuits/` b
 
 Tests use **real** ZK where applicable: circuits are compiled with Circom, then a small Powers of Tau and zkey are generated, and a Groth16 proof is created and verified with snarkjs (no mocks).
 
-**Coverage** (153+ tests): Poseidon, PoseidonEncrypt, SHA-256, Comparators, IdentityCommitment, SemaphoreMembership, AccumulatorMembership, Gates, Bitify, Merkle (inclusion, AllowlistMembership, sparse, incremental, update), MiMC, Mux1/Mux2, MuxN, Arithmetic (incl. PoEVerify), Utils (PadBits, PadBits10Star, PadPKCS7, OneOfN, IndexOf, Min2, Max2, MinN, MaxN, AllEqual, CountMatches, Tally, ConditionalSelect, BalanceProof, VoteInAllowlist), String (Utf8Validation, FixedStringMatch, BytesAllInRange), Switcher, VoteCommitAllowlist, Nullifier, Voting, MACI, and one full Groth16 prove/verify.
+**Coverage** (163+ tests): Poseidon, PoseidonEncrypt, SHA-256, Comparators, IdentityCommitment, SemaphoreMembership, AccumulatorMembership, Gates (incl. SafeAND/SafeOR), Bitify (incl. SafeBits2Num), Merkle (inclusion, AllowlistMembership, sparse, incremental, update), MiMC, Mux1/Mux2/SafeMux1/SafeMux2, MuxN, Arithmetic (incl. PoEVerify), Utils (PadBits, PadBits10Star, PadPKCS7, OneOfN, IndexOf, Min2, Max2, MinN, MaxN, AllEqual, CountMatches, Tally, ConditionalSelect, BalanceProof, VoteInAllowlist), String (Utf8Validation, FixedStringMatch, BytesAllInRange), Switcher, VoteCommitAllowlist, Nullifier, Voting, MACI, and one full Groth16 prove/verify.
 
 ```bash
 npm install

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,10 +12,16 @@
 - Parameter `n`: inputs must be in range `[0, 2^n - 1]`. Use `n` large enough (e.g. 64 or 253) for your application.
 - `IsZero` uses a witness for the inverse; ensure your backend produces valid proofs.
 
-### Bitify (`Num2Bits`, `Bits2Num`)
+### Bitify (`Num2Bits`, `Bits2Num`, `SafeBits2Num`)
 
 - `Num2Bits(n)` proves `in` equals the sum of bits; use `n` such that `in < 2^n` in your field.
+- `Bits2Num(n)` does **not** binary-constrain `in[i]` (building block). Prefer `SafeBits2Num(n)` when bit arrays may be untrusted.
 - For full field range (254-bit) use `AliasCheck` with `Num2Bits(254)` outputs.
+
+### Gates & mux (`AND`, `OR`, `Mux1`, `Mux2` and Safe*)
+
+- Raw `AND`, `OR`, `Mux1`, `Mux2` assume binary inputs/selectors by design and do **not** enforce them (documented in the 0.5.0 audit).
+- Prefer `SafeAND()`, `SafeOR()`, `SafeMux1()`, `SafeMux2()` for untrusted bits or selectors; each adds `x*(x-1)===0` constraints before the underlying building block.
 
 ### Poseidon / MiMC
 

--- a/circuits/bitify.circom
+++ b/circuits/bitify.circom
@@ -27,10 +27,11 @@ template Num2Bits(n) {
 /**
  * @title Bits2Num
  * @notice Recomposes n bits into a single field element.
- * @dev out = sum(in[i]*2^i). No binary check on in[i]; use with Num2Bits or constrain inputs elsewhere.
+ * @dev Building-block-only: no binary check on in[i]. Prefer SafeBits2Num when bits may be untrusted.
  * @param n Number of bits.
- * @custom:input in[n] Bits (in[0] = LSB).
+ * @custom:input in[n] Bits (in[0] = LSB; not binary-enforced here).
  * @custom:output out Field element.
+ * @custom:security Prefer SafeBits2Num(n) when in[i] may be untrusted.
  */
 template Bits2Num(n) {
     signal input in[n];
@@ -42,6 +43,29 @@ template Bits2Num(n) {
         e2 = e2 + e2;
     }
     lc1 ==> out;
+}
+
+/**
+ * @title SafeBits2Num
+ * @notice Recomposes n bits into a field element with each bit binary-constrained.
+ * @dev Wraps Bits2Num(n) and enforces in[i]*(in[i]-1)===0 for all i. Prefer over Bits2Num for untrusted bit arrays.
+ * @param n Number of bits.
+ * @custom:input in[n] Bits (in[0] = LSB; each constrained to 0 or 1).
+ * @custom:output out Field element.
+ * @custom:complexity O(n): n binary constraints + Bits2Num.
+ * @custom:security Bit inputs are binary-constrained in-circuit.
+ */
+template SafeBits2Num(n) {
+    signal input in[n];
+    signal output out;
+    for (var i = 0; i < n; i++) {
+        in[i] * (in[i] - 1) === 0;
+    }
+    component b2n = Bits2Num(n);
+    for (var i = 0; i < n; i++) {
+        b2n.in[i] <== in[i];
+    }
+    out <== b2n.out;
 }
 
 /**

--- a/circuits/gates.circom
+++ b/circuits/gates.circom
@@ -20,10 +20,11 @@ template XOR() {
 /**
  * @title AND
  * @notice Boolean AND: out = a * b.
- * @dev Inputs 0 or 1. One constraint.
- * @custom:input a First bit.
- * @custom:input b Second bit.
+ * @dev Building-block-only: does not binary-constrain a, b. Prefer SafeAND for untrusted inputs.
+ * @custom:input a First bit (must be 0 or 1; not enforced here).
+ * @custom:input b Second bit (must be 0 or 1; not enforced here).
  * @custom:output out a AND b.
+ * @custom:security Prefer SafeAND() when a, b may be untrusted.
  */
 template AND() {
     signal input a;
@@ -33,18 +34,63 @@ template AND() {
 }
 
 /**
+ * @title SafeAND
+ * @notice Boolean AND with binary-constrained inputs: out = a * b, a,b ∈ {0,1}.
+ * @dev Wraps AND with a*(a-1)===0 and b*(b-1)===0. Prefer over AND for untrusted selectors/bits.
+ * @custom:input a First bit (constrained to 0 or 1).
+ * @custom:input b Second bit (constrained to 0 or 1).
+ * @custom:output out a AND b.
+ * @custom:complexity 3 constraints (2 binary + 1 AND).
+ * @custom:security Inputs are binary-constrained in-circuit.
+ */
+template SafeAND() {
+    signal input a;
+    signal input b;
+    signal output out;
+    a * (a - 1) === 0;
+    b * (b - 1) === 0;
+    component g = AND();
+    g.a <== a;
+    g.b <== b;
+    out <== g.out;
+}
+
+/**
  * @title OR
  * @notice Boolean OR: out = 1 iff at least one of a, b is 1.
- * @dev out = a + b - a*b. One constraint.
- * @custom:input a First bit.
- * @custom:input b Second bit.
+ * @dev Building-block-only: does not binary-constrain a, b. Prefer SafeOR for untrusted inputs.
+ * @custom:input a First bit (must be 0 or 1; not enforced here).
+ * @custom:input b Second bit (must be 0 or 1; not enforced here).
  * @custom:output out a OR b.
+ * @custom:security Prefer SafeOR() when a, b may be untrusted.
  */
 template OR() {
     signal input a;
     signal input b;
     signal output out;
     out <== a + b - a * b;
+}
+
+/**
+ * @title SafeOR
+ * @notice Boolean OR with binary-constrained inputs.
+ * @dev Wraps OR with a*(a-1)===0 and b*(b-1)===0. Prefer over OR for untrusted selectors/bits.
+ * @custom:input a First bit (constrained to 0 or 1).
+ * @custom:input b Second bit (constrained to 0 or 1).
+ * @custom:output out a OR b.
+ * @custom:complexity 3 constraints (2 binary + 1 OR).
+ * @custom:security Inputs are binary-constrained in-circuit.
+ */
+template SafeOR() {
+    signal input a;
+    signal input b;
+    signal output out;
+    a * (a - 1) === 0;
+    b * (b - 1) === 0;
+    component g = OR();
+    g.a <== a;
+    g.b <== b;
+    out <== g.out;
 }
 
 /**

--- a/circuits/mux1.circom
+++ b/circuits/mux1.circom
@@ -21,10 +21,11 @@ template MultiMux1(n) {
 /**
  * @title Mux1
  * @notice Single 2-to-1 multiplexer: out = c[1] if s else c[0].
- * @dev Wrapper of MultiMux1(1).
+ * @dev Building-block-only: does not binary-constrain s. Prefer SafeMux1 for untrusted selectors.
  * @custom:input c[2] Two choices c[0], c[1].
- * @custom:input s Selector (0 or 1).
+ * @custom:input s Selector (0 or 1; not enforced here).
  * @custom:output out Selected value.
+ * @custom:security Prefer SafeMux1() when s may be untrusted.
  */
 template Mux1() {
     signal input c[2];
@@ -36,4 +37,26 @@ template Mux1() {
     }
     s ==> mux.s;
     mux.out[0] ==> out;
+}
+
+/**
+ * @title SafeMux1
+ * @notice 2-to-1 multiplexer with binary-constrained selector.
+ * @dev Wraps Mux1 with s*(s-1)===0. Prefer over Mux1 for untrusted selectors.
+ * @custom:input c[2] Two choices c[0], c[1].
+ * @custom:input s Selector (constrained to 0 or 1).
+ * @custom:output out Selected value.
+ * @custom:complexity Mux1 cost + 1 binary constraint.
+ * @custom:security Selector is binary-constrained in-circuit.
+ */
+template SafeMux1() {
+    signal input c[2];
+    signal input s;
+    signal output out;
+    s * (s - 1) === 0;
+    component mux = Mux1();
+    mux.c[0] <== c[0];
+    mux.c[1] <== c[1];
+    mux.s <== s;
+    out <== mux.out;
 }

--- a/circuits/mux2.circom
+++ b/circuits/mux2.circom
@@ -31,10 +31,11 @@ template MultiMux2(n) {
 /**
  * @title Mux2
  * @notice Single 4-to-1 multiplexer: out = c[s[0] + 2*s[1]].
- * @dev Wrapper of MultiMux2(1).
+ * @dev Building-block-only: does not binary-constrain s[0], s[1]. Prefer SafeMux2 for untrusted selectors.
  * @custom:input c[4] Four choices.
- * @custom:input s[2] Selector bits.
+ * @custom:input s[2] Selector bits (must be 0/1; not enforced here).
  * @custom:output out Selected value.
+ * @custom:security Prefer SafeMux2() when s may be untrusted.
  */
 template Mux2() {
     signal input c[4];
@@ -48,4 +49,29 @@ template Mux2() {
         s[i] ==> mux.s[i];
     }
     mux.out[0] ==> out;
+}
+
+/**
+ * @title SafeMux2
+ * @notice 4-to-1 multiplexer with binary-constrained selector bits.
+ * @dev Wraps Mux2 with s[i]*(s[i]-1)===0 for i in {0,1}. Prefer over Mux2 for untrusted selectors.
+ * @custom:input c[4] Four choices.
+ * @custom:input s[2] Selector bits (each constrained to 0 or 1).
+ * @custom:output out Selected value.
+ * @custom:complexity Mux2 cost + 2 binary constraints.
+ * @custom:security Selector bits are binary-constrained in-circuit.
+ */
+template SafeMux2() {
+    signal input c[4];
+    signal input s[2];
+    signal output out;
+    s[0] * (s[0] - 1) === 0;
+    s[1] * (s[1] - 1) === 0;
+    component mux = Mux2();
+    for (var i = 0; i < 4; i++) {
+        mux.c[i] <== c[i];
+    }
+    mux.s[0] <== s[0];
+    mux.s[1] <== s[1];
+    out <== mux.out;
 }

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="OpenCircom v0.7.0 documentation — installation, CLI, Hardhat/Foundry integration, security, and full circuit template reference." />
+  <meta name="description" content="OpenCircom v0.8.0 documentation — installation, CLI, Hardhat/Foundry integration, security, and full circuit template reference." />
   <title>Documentation — OpenCircom</title>
   <link rel="icon" href="assets/img/logo.png" type="image/png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -40,12 +40,12 @@
       <header class="docs-header">
         <p class="section-label">Documentation</p>
         <h1>OpenCircom reference</h1>
-        <p class="docs-lead">v0.7.0 — 96 circuit templates, CLI tooling, integration guides, and auto-generated template reference from <code>circuits/**/*.circom</code>.</p>
+        <p class="docs-lead">v0.8.0 — 101 circuit templates, CLI tooling, integration guides, and auto-generated template reference from <code>circuits/**/*.circom</code>.</p>
       </header>
 
       <section class="docs-section" id="overview">
         <h2>Overview</h2>
-        <p>OpenCircom is a library of reusable <strong>Circom 2.x</strong> templates for zero-knowledge applications: hashing (Poseidon, MiMC, SHA-256), comparators, Merkle proofs, identity (Semaphore-style), voting, MACI v1 building blocks, and utilities. There is <strong>no dependency on circomlib</strong>; implementations are self-contained and covered by 153+ real Groth16 tests.</p>
+        <p>OpenCircom is a library of reusable <strong>Circom 2.x</strong> templates for zero-knowledge applications: hashing (Poseidon, MiMC, SHA-256), comparators, Merkle proofs, identity (Semaphore-style), voting, MACI v1 building blocks, and utilities. There is <strong>no dependency on circomlib</strong>; implementations are self-contained and covered by 163+ real Groth16 tests.</p>
         <p>Install via npm, add the circuits folder to your Circom include path (<code>-l</code>), and compose templates in your own circuits. Use the <a href="https://github.com/jose-compu/opencircom-hardhat-boilerplate" target="_blank" rel="noopener">Hardhat</a> or <a href="https://github.com/jose-compu/opencircom-foundry-boilerplate" target="_blank" rel="noopener">Foundry</a> boilerplates for a full compile → verifier → test pipeline.</p>
       </section>
 
@@ -53,7 +53,7 @@
         <h2>Installation</h2>
         <pre class="code-block"><code class="language-bash">npm install opencircom</code></pre>
         <p>Peer dependency: <strong>circom 2.x</strong> must be installed and available on <code>PATH</code>. OpenCircom does not bundle the compiler.</p>
-        <p>Package version: <code>^0.7.0</code>. Circuits live under <code>node_modules/opencircom/circuits/</code>.</p>
+        <p>Package version: <code>^0.8.0</code>. Circuits live under <code>node_modules/opencircom/circuits/</code>.</p>
       </section>
 
       <section class="docs-section" id="includes">
@@ -97,7 +97,7 @@ npx opencircom path</code></pre>
 
       <section class="docs-section" id="cli-ref">
         <h2>CLI reference</h2>
-        <p>The <code>opencircom</code> CLI ships with the npm package (v0.7.0+):</p>
+        <p>The <code>opencircom</code> CLI ships with the npm package (v0.7.0+; current <code>^0.8.0</code>):</p>
         <div class="docs-table-wrap">
           <table class="docs-table">
             <thead><tr><th>Command</th><th>Description</th></tr></thead>
@@ -127,10 +127,11 @@ npm test</code></pre>
         <h2>Security</h2>
         <ul class="docs-list">
           <li><strong>Range checks:</strong> Use <code>StrictNum2Bits(n)</code> or <code>RangeProof(n)</code> for untrusted inputs; <code>LessThan(n)</code> assumes inputs &lt; 2<sup>n</sup>.</li>
+          <li><strong>Binary selectors / bits:</strong> Prefer <code>SafeAND</code>, <code>SafeOR</code>, <code>SafeMux1</code>, <code>SafeMux2</code>, <code>SafeBits2Num(n)</code> for untrusted inputs. Raw AND/OR/Mux1/Mux2/Bits2Num are building blocks without binary constraints.</li>
           <li><strong>Merkle:</strong> <code>pathIndices[i]</code> are constrained binary in-circuit; <code>Switcher</code> constrains <code>sel</code> to {0,1}.</li>
           <li><strong>Nullifier:</strong> Use a unique <code>externalNullifier</code> per action to avoid cross-action replay.</li>
           <li><strong>Hashing:</strong> Poseidon uses standard Hades parameters; constants in <code>circuits/hashing/poseidon_constants.circom</code>.</li>
-          <li><strong>Audit (0.5.0):</strong> Binary constraints and range checks hardened in Switcher, ForceEqualIfEnabled, IncrementalMerkleInclusion, DivRem, and PadPKCS7.</li>
+          <li><strong>Audit (0.5.0) / Safe wrappers (0.8.0):</strong> Binary constraints and range checks hardened in Switcher, ForceEqualIfEnabled, IncrementalMerkleInclusion, DivRem, and PadPKCS7; Safe* templates added for gates, mux, and Bits2Num.</li>
           <li><strong>MACI:</strong> EdDSA, ECDH shared keys, and full DuplexSponge encryption remain off-circuit (coordinator layer). See <a href="https://maci.pse.dev/docs/v1.2/spec">MACI v1 spec</a>.</li>
         </ul>
         <p>Full notes: <a href="https://github.com/jose-compu/opencircom/blob/main/SECURITY.md">SECURITY.md</a> on GitHub.</p>
@@ -307,7 +308,7 @@ npm test</code></pre>
 
 <section class="docs-category" id="cat-bitify">
 <h2>Bitify</h2>
-<p class="docs-category-intro">4 templates in this category.</p>
+<p class="docs-category-intro">5 templates in this category.</p>
 <article class="template-doc" id="Num2Bits-bitify-circom" data-search="num2bits decomposes a field element into n bits (out[0] = lsb). bitify.circom n o(n): n binary constraints + 1 linear combo. no upper bound on in; use strictnum2bits when in must be in [0,2^n-1]. if in &gt;= 2^n, decomposition is mod field; can break range assumptions. use strictnum2bits for untrusted inputs. enforces in === sum(out[i]*2^i) and each out[i] in {0,1}. use n small enough for the field modulus. n number of bits. in out">
 <h3 class="template-name"><code>Num2Bits(n)</code></h3>
 <p class="template-notice">Decomposes a field element into n bits (out[0] = LSB).</p>
@@ -320,10 +321,23 @@ npm test</code></pre>
 <dt>Outputs</dt><dd><ul><li><code>out[n]</code></li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/bitify.circom</code></p>
 </article>
-<article class="template-doc" id="Bits2Num-bitify-circom" data-search="bits2num recomposes n bits into a single field element. bitify.circom n out = sum(in[i]*2^i). no binary check on in[i]; use with num2bits or constrain inputs elsewhere. n number of bits. in out">
+<article class="template-doc" id="Bits2Num-bitify-circom" data-search="bits2num recomposes n bits into a single field element. bitify.circom n prefer safebits2num(n) when in[i] may be untrusted. building-block-only: no binary check on in[i]. prefer safebits2num when bits may be untrusted. n number of bits. in out">
 <h3 class="template-name"><code>Bits2Num(n)</code></h3>
 <p class="template-notice">Recomposes n bits into a single field element.</p>
-<p class="template-dev"><strong>Dev:</strong> out = sum(in[i]*2^i). No binary check on in[i]; use with Num2Bits or constrain inputs elsewhere.</p>
+<p class="template-dev"><strong>Dev:</strong> Building-block-only: no binary check on in[i]. Prefer SafeBits2Num when bits may be untrusted.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Prefer SafeBits2Num(n) when in[i] may be untrusted.</p>
+<dl class="template-dl">
+<dt>Parameters</dt><dd><ul><li><code>n</code> — Number of bits.</li></ul></dd>
+<dt>Inputs</dt><dd><ul><li><code>in[n]</code></li></ul></dd>
+<dt>Outputs</dt><dd><ul><li><code>out</code> — Field element.</li></ul></dd></dl>
+<p class="template-file">Defined in <code>circuits/bitify.circom</code></p>
+</article>
+<article class="template-doc" id="SafeBits2Num-bitify-circom" data-search="safebits2num recomposes n bits into a field element with each bit binary-constrained. bitify.circom n o(n): n binary constraints + bits2num. bit inputs are binary-constrained in-circuit. wraps bits2num(n) and enforces in[i]*(in[i]-1)===0 for all i. prefer over bits2num for untrusted bit arrays. n number of bits. in out">
+<h3 class="template-name"><code>SafeBits2Num(n)</code></h3>
+<p class="template-notice">Recomposes n bits into a field element with each bit binary-constrained.</p>
+<p class="template-dev"><strong>Dev:</strong> Wraps Bits2Num(n) and enforces in[i]*(in[i]-1)===0 for all i. Prefer over Bits2Num for untrusted bit arrays.</p>
+<p class="template-meta"><strong>Complexity:</strong> O(n): n binary constraints + Bits2Num.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Bit inputs are binary-constrained in-circuit.</p>
 <dl class="template-dl">
 <dt>Parameters</dt><dd><ul><li><code>n</code> — Number of bits.</li></ul></dd>
 <dt>Inputs</dt><dd><ul><li><code>in[n]</code></li></ul></dd>
@@ -354,7 +368,7 @@ npm test</code></pre>
 
 <section class="docs-category" id="cat-gates">
 <h2>Gates</h2>
-<p class="docs-category-intro">7 templates in this category.</p>
+<p class="docs-category-intro">9 templates in this category.</p>
 <article class="template-doc" id="XOR-gates-circom" data-search="xor boolean xor: out = 1 iff exactly one of a, b is 1. gates.circom 1 constraint. inputs must be 0 or 1 (enforce with bitify or range checks). no security caveats; use with binary-constrained inputs. inputs must be 0 or 1; use with bitify for range checks. one constraint. a b out">
 <h3 class="template-name"><code>XOR()</code></h3>
 <p class="template-notice">Boolean XOR: out = 1 iff exactly one of a, b is 1.</p>
@@ -365,19 +379,41 @@ npm test</code></pre>
 <dt>Outputs</dt><dd><ul><li><code>out</code> — a XOR b.</li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/gates.circom</code></p>
 </article>
-<article class="template-doc" id="AND-gates-circom" data-search="and boolean and: out = a * b. gates.circom inputs 0 or 1. one constraint. a b out">
+<article class="template-doc" id="AND-gates-circom" data-search="and boolean and: out = a * b. gates.circom prefer safeand() when a, b may be untrusted. building-block-only: does not binary-constrain a, b. prefer safeand for untrusted inputs. a b out">
 <h3 class="template-name"><code>AND()</code></h3>
 <p class="template-notice">Boolean AND: out = a * b.</p>
-<p class="template-dev"><strong>Dev:</strong> Inputs 0 or 1. One constraint.</p>
-<dt>Inputs</dt><dd><ul><li><code>a</code> — First bit.</li><li><code>b</code> — Second bit.</li></ul></dd>
+<p class="template-dev"><strong>Dev:</strong> Building-block-only: does not binary-constrain a, b. Prefer SafeAND for untrusted inputs.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Prefer SafeAND() when a, b may be untrusted.</p>
+<dt>Inputs</dt><dd><ul><li><code>a</code> — First bit (must be 0 or 1; not enforced here).</li><li><code>b</code> — Second bit (must be 0 or 1; not enforced here).</li></ul></dd>
 <dt>Outputs</dt><dd><ul><li><code>out</code> — a AND b.</li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/gates.circom</code></p>
 </article>
-<article class="template-doc" id="OR-gates-circom" data-search="or boolean or: out = 1 iff at least one of a, b is 1. gates.circom out = a + b - a*b. one constraint. a b out">
+<article class="template-doc" id="SafeAND-gates-circom" data-search="safeand boolean and with binary-constrained inputs: out = a * b, a,b ∈ {0,1}. gates.circom 3 constraints (2 binary + 1 and). inputs are binary-constrained in-circuit. wraps and with a*(a-1)===0 and b*(b-1)===0. prefer over and for untrusted selectors/bits. a b out">
+<h3 class="template-name"><code>SafeAND()</code></h3>
+<p class="template-notice">Boolean AND with binary-constrained inputs: out = a * b, a,b ∈ {0,1}.</p>
+<p class="template-dev"><strong>Dev:</strong> Wraps AND with a*(a-1)===0 and b*(b-1)===0. Prefer over AND for untrusted selectors/bits.</p>
+<p class="template-meta"><strong>Complexity:</strong> 3 constraints (2 binary + 1 AND).</p>
+<p class="template-meta template-security"><strong>Security:</strong> Inputs are binary-constrained in-circuit.</p>
+<dt>Inputs</dt><dd><ul><li><code>a</code> — First bit (constrained to 0 or 1).</li><li><code>b</code> — Second bit (constrained to 0 or 1).</li></ul></dd>
+<dt>Outputs</dt><dd><ul><li><code>out</code> — a AND b.</li></ul></dd></dl>
+<p class="template-file">Defined in <code>circuits/gates.circom</code></p>
+</article>
+<article class="template-doc" id="OR-gates-circom" data-search="or boolean or: out = 1 iff at least one of a, b is 1. gates.circom prefer safeor() when a, b may be untrusted. building-block-only: does not binary-constrain a, b. prefer safeor for untrusted inputs. a b out">
 <h3 class="template-name"><code>OR()</code></h3>
 <p class="template-notice">Boolean OR: out = 1 iff at least one of a, b is 1.</p>
-<p class="template-dev"><strong>Dev:</strong> out = a + b - a*b. One constraint.</p>
-<dt>Inputs</dt><dd><ul><li><code>a</code> — First bit.</li><li><code>b</code> — Second bit.</li></ul></dd>
+<p class="template-dev"><strong>Dev:</strong> Building-block-only: does not binary-constrain a, b. Prefer SafeOR for untrusted inputs.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Prefer SafeOR() when a, b may be untrusted.</p>
+<dt>Inputs</dt><dd><ul><li><code>a</code> — First bit (must be 0 or 1; not enforced here).</li><li><code>b</code> — Second bit (must be 0 or 1; not enforced here).</li></ul></dd>
+<dt>Outputs</dt><dd><ul><li><code>out</code> — a OR b.</li></ul></dd></dl>
+<p class="template-file">Defined in <code>circuits/gates.circom</code></p>
+</article>
+<article class="template-doc" id="SafeOR-gates-circom" data-search="safeor boolean or with binary-constrained inputs. gates.circom 3 constraints (2 binary + 1 or). inputs are binary-constrained in-circuit. wraps or with a*(a-1)===0 and b*(b-1)===0. prefer over or for untrusted selectors/bits. a b out">
+<h3 class="template-name"><code>SafeOR()</code></h3>
+<p class="template-notice">Boolean OR with binary-constrained inputs.</p>
+<p class="template-dev"><strong>Dev:</strong> Wraps OR with a*(a-1)===0 and b*(b-1)===0. Prefer over OR for untrusted selectors/bits.</p>
+<p class="template-meta"><strong>Complexity:</strong> 3 constraints (2 binary + 1 OR).</p>
+<p class="template-meta template-security"><strong>Security:</strong> Inputs are binary-constrained in-circuit.</p>
+<dt>Inputs</dt><dd><ul><li><code>a</code> — First bit (constrained to 0 or 1).</li><li><code>b</code> — Second bit (constrained to 0 or 1).</li></ul></dd>
 <dt>Outputs</dt><dd><ul><li><code>out</code> — a OR b.</li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/gates.circom</code></p>
 </article>
@@ -419,7 +455,7 @@ npm test</code></pre>
 
 <section class="docs-category" id="cat-mux">
 <h2>Mux &amp; select</h2>
-<p class="docs-category-intro">6 templates in this category.</p>
+<p class="docs-category-intro">8 templates in this category.</p>
 <article class="template-doc" id="MultiMux1-mux1-circom" data-search="multimux1 2-to-1 multiplexer for n parallel signals: out[i] = c[i][1] if s else c[i][0]. mux1.circom n out[i] = (c[i][1] - c[i][0])*s + c[i][0]. one constraint per output. n number of parallel channels. c s out">
 <h3 class="template-name"><code>MultiMux1(n)</code></h3>
 <p class="template-notice">2-to-1 multiplexer for n parallel signals: out[i] = c[i][1] if s else c[i][0].</p>
@@ -430,11 +466,22 @@ npm test</code></pre>
 <dt>Outputs</dt><dd><ul><li><code>out[n]</code></li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/mux1.circom</code></p>
 </article>
-<article class="template-doc" id="Mux1-mux1-circom" data-search="mux1 single 2-to-1 multiplexer: out = c[1] if s else c[0]. mux1.circom wrapper of multimux1(1). c s out">
+<article class="template-doc" id="Mux1-mux1-circom" data-search="mux1 single 2-to-1 multiplexer: out = c[1] if s else c[0]. mux1.circom prefer safemux1() when s may be untrusted. building-block-only: does not binary-constrain s. prefer safemux1 for untrusted selectors. c s out">
 <h3 class="template-name"><code>Mux1()</code></h3>
 <p class="template-notice">Single 2-to-1 multiplexer: out = c[1] if s else c[0].</p>
-<p class="template-dev"><strong>Dev:</strong> Wrapper of MultiMux1(1).</p>
-<dt>Inputs</dt><dd><ul><li><code>c[2]</code></li><li><code>s</code> — Selector (0 or 1).</li></ul></dd>
+<p class="template-dev"><strong>Dev:</strong> Building-block-only: does not binary-constrain s. Prefer SafeMux1 for untrusted selectors.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Prefer SafeMux1() when s may be untrusted.</p>
+<dt>Inputs</dt><dd><ul><li><code>c[2]</code></li><li><code>s</code> — Selector (0 or 1; not enforced here).</li></ul></dd>
+<dt>Outputs</dt><dd><ul><li><code>out</code> — Selected value.</li></ul></dd></dl>
+<p class="template-file">Defined in <code>circuits/mux1.circom</code></p>
+</article>
+<article class="template-doc" id="SafeMux1-mux1-circom" data-search="safemux1 2-to-1 multiplexer with binary-constrained selector. mux1.circom mux1 cost + 1 binary constraint. selector is binary-constrained in-circuit. wraps mux1 with s*(s-1)===0. prefer over mux1 for untrusted selectors. c s out">
+<h3 class="template-name"><code>SafeMux1()</code></h3>
+<p class="template-notice">2-to-1 multiplexer with binary-constrained selector.</p>
+<p class="template-dev"><strong>Dev:</strong> Wraps Mux1 with s*(s-1)===0. Prefer over Mux1 for untrusted selectors.</p>
+<p class="template-meta"><strong>Complexity:</strong> Mux1 cost + 1 binary constraint.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Selector is binary-constrained in-circuit.</p>
+<dt>Inputs</dt><dd><ul><li><code>c[2]</code></li><li><code>s</code> — Selector (constrained to 0 or 1).</li></ul></dd>
 <dt>Outputs</dt><dd><ul><li><code>out</code> — Selected value.</li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/mux1.circom</code></p>
 </article>
@@ -448,10 +495,21 @@ npm test</code></pre>
 <dt>Outputs</dt><dd><ul><li><code>out[n]</code></li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/mux2.circom</code></p>
 </article>
-<article class="template-doc" id="Mux2-mux2-circom" data-search="mux2 single 4-to-1 multiplexer: out = c[s[0] + 2*s[1]]. mux2.circom wrapper of multimux2(1). c s out">
+<article class="template-doc" id="Mux2-mux2-circom" data-search="mux2 single 4-to-1 multiplexer: out = c[s[0] + 2*s[1]]. mux2.circom prefer safemux2() when s may be untrusted. building-block-only: does not binary-constrain s[0], s[1]. prefer safemux2 for untrusted selectors. c s out">
 <h3 class="template-name"><code>Mux2()</code></h3>
 <p class="template-notice">Single 4-to-1 multiplexer: out = c[s[0] + 2*s[1]].</p>
-<p class="template-dev"><strong>Dev:</strong> Wrapper of MultiMux2(1).</p>
+<p class="template-dev"><strong>Dev:</strong> Building-block-only: does not binary-constrain s[0], s[1]. Prefer SafeMux2 for untrusted selectors.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Prefer SafeMux2() when s may be untrusted.</p>
+<dt>Inputs</dt><dd><ul><li><code>c[4]</code></li><li><code>s[2]</code></li></ul></dd>
+<dt>Outputs</dt><dd><ul><li><code>out</code> — Selected value.</li></ul></dd></dl>
+<p class="template-file">Defined in <code>circuits/mux2.circom</code></p>
+</article>
+<article class="template-doc" id="SafeMux2-mux2-circom" data-search="safemux2 4-to-1 multiplexer with binary-constrained selector bits. mux2.circom mux2 cost + 2 binary constraints. selector bits are binary-constrained in-circuit. wraps mux2 with s[i]*(s[i]-1)===0 for i in {0,1}. prefer over mux2 for untrusted selectors. c s out">
+<h3 class="template-name"><code>SafeMux2()</code></h3>
+<p class="template-notice">4-to-1 multiplexer with binary-constrained selector bits.</p>
+<p class="template-dev"><strong>Dev:</strong> Wraps Mux2 with s[i]*(s[i]-1)===0 for i in {0,1}. Prefer over Mux2 for untrusted selectors.</p>
+<p class="template-meta"><strong>Complexity:</strong> Mux2 cost + 2 binary constraints.</p>
+<p class="template-meta template-security"><strong>Security:</strong> Selector bits are binary-constrained in-circuit.</p>
 <dt>Inputs</dt><dd><ul><li><code>c[4]</code></li><li><code>s[2]</code></li></ul></dd>
 <dt>Outputs</dt><dd><ul><li><code>out</code> — Selected value.</li></ul></dd></dl>
 <p class="template-file">Defined in <code>circuits/mux2.circom</code></p>
@@ -1080,7 +1138,7 @@ npm test</code></pre>
         <a href="https://www.npmjs.com/package/opencircom">npm</a>
         <a href="https://github.com/jose-compu/opencircom/blob/main/LICENSE">MIT License</a>
       </div>
-      <p class="footer-copy">OpenCircom v0.7.0 · Generated by <code>npm run docs</code></p>
+      <p class="footer-copy">OpenCircom v0.8.0 · Generated by <code>npm run docs</code></p>
     </div>
   </footer>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="OpenCircom — reusable Circom ZK circuit templates. Hashing, Merkle trees, voting, MACI, identity. No circomlib dependency. v0.7.0." />
+  <meta name="description" content="OpenCircom — reusable Circom ZK circuit templates. Hashing, Merkle trees, voting, MACI, identity. No circomlib dependency. v0.8.0." />
   <title>OpenCircom — Reusable ZK Circuits</title>
   <link rel="icon" href="assets/img/logo.png" type="image/png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -36,7 +36,7 @@
       <div class="container hero-grid">
         <div>
           <p class="section-label">Zero-knowledge circuits</p>
-          <p class="version-badge">v0.7.0</p>
+          <p class="version-badge">v0.8.0</p>
           <h1>
             <span class="word-blue">Reusable.</span>
             <span class="word-silver">Secure.</span>
@@ -53,7 +53,7 @@
             <a href="https://www.npmjs.com/package/opencircom"><img src="https://img.shields.io/npm/v/opencircom.svg?style=flat-square&amp;label=npm" alt="npm version" /></a>
             <img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" alt="MIT License" />
             <img src="https://img.shields.io/badge/Circom-2.x-8B5CF6?style=flat-square" alt="Circom 2.x" />
-            <img src="https://img.shields.io/badge/tests-153%2B%20passing-success?style=flat-square" alt="153+ tests" />
+            <img src="https://img.shields.io/badge/tests-163%2B%20passing-success?style=flat-square" alt="163+ tests" />
             <img src="https://img.shields.io/badge/deps-no%20circomlib-informational?style=flat-square" alt="No circomlib" />
           </div>
         </div>
@@ -109,7 +109,7 @@
           <article class="feature-card blue">
             <div class="icon">🧪</div>
             <h3>Real ZK tests</h3>
-            <p>153+ tests compile circuits, run Powers of Tau setup, generate Groth16 proofs with snarkjs, and verify — no mocks on the critical path.</p>
+            <p>163+ tests compile circuits, run Powers of Tau setup, generate Groth16 proofs with snarkjs, and verify — no mocks on the critical path.</p>
           </article>
           <article class="feature-card silver">
             <div class="icon">📦</div>
@@ -124,7 +124,7 @@
             <span class="label">Circuit templates</span>
           </div>
           <div class="stat-card">
-            <span class="value">153+</span>
+            <span class="value">163+</span>
             <span class="label">Passing tests</span>
           </div>
           <div class="stat-card">
@@ -142,7 +142,7 @@
     <section id="circuits">
       <div class="container">
         <span class="section-label">Library</span>
-        <h2>Circuit categories — v0.7.0</h2>
+        <h2>Circuit categories — v0.8.0</h2>
         <p class="section-intro">
           Templates span hashing, set membership, identity, voting, and MACI building blocks.
           Run <code>npx opencircom list</code> for the full catalog with descriptions, or see the <a href="documentation.html#reference">documentation reference</a>.
@@ -155,7 +155,7 @@
           </article>
           <article class="circuit-card">
             <h3>Comparators &amp; bitify</h3>
-            <p><code>LessThan</code>, <code>RangeProof</code>, <code>Num2Bits</code>, <code>StrictNum2Bits</code></p>
+            <p><code>LessThan</code>, <code>RangeProof</code>, <code>Num2Bits</code>, <code>StrictNum2Bits</code>, <code>SafeBits2Num</code></p>
           </article>
           <article class="circuit-card">
             <h3>Merkle &amp; sets</h3>
@@ -175,7 +175,7 @@
           </article>
           <article class="circuit-card">
             <h3>Arithmetic &amp; utils</h3>
-            <p><code>Sum</code>, <code>DivRem</code>, <code>ExpByBits</code>, mux/select, <code>BalanceProof</code>, padding</p>
+            <p><code>Sum</code>, <code>DivRem</code>, <code>ExpByBits</code>, Safe mux/gates, <code>BalanceProof</code>, padding</p>
           </article>
           <article class="circuit-card">
             <h3>String &amp; data</h3>
@@ -184,7 +184,7 @@
         </div>
 
         <div class="callout">
-          <strong>Security audit (0.5.0):</strong> Binary constraints and range checks hardened in Switcher, ForceEqualIfEnabled, IncrementalMerkleInclusion, DivRem, and PadPKCS7. See <a href="https://github.com/jose-compu/opencircom/blob/main/SECURITY.md">SECURITY.md</a>.
+          <strong>Safe wrappers (0.8.0):</strong> Prefer <code>SafeAND</code>, <code>SafeOR</code>, <code>SafeMux1</code>, <code>SafeMux2</code>, <code>SafeBits2Num</code> for untrusted binary inputs. Audit fixes from 0.5.0 remain; see <a href="https://github.com/jose-compu/opencircom/blob/main/SECURITY.md">SECURITY.md</a>.
         </div>
       </div>
     </section>
@@ -192,7 +192,7 @@
     <section id="cli" class="alt">
       <div class="container">
         <span class="section-label">Tooling</span>
-        <h2>CLI — new in 0.7.0</h2>
+        <h2>CLI — since 0.7.0</h2>
         <p class="section-intro">
           Requires <strong>circom 2.x</strong> on <code>PATH</code> (peer dependency). The CLI adds the include path automatically and scaffolds starter circuits.
         </p>
@@ -266,7 +266,7 @@
     <section id="documentation" class="alt">
       <div class="container">
         <span class="section-label">Documentation</span>
-        <h2>Full reference — v0.7.0</h2>
+        <h2>Full reference — v0.8.0</h2>
         <p class="section-intro">
           Installation guides, Hardhat/Foundry integration, CLI commands, security notes, and a searchable catalog of every circuit template with inputs, outputs, and parameters.
         </p>
@@ -353,7 +353,7 @@ template MyCircuit(levels) {
         <a href="documentation.html">Documentation</a>
         <a href="https://github.com/jose-compu/opencircom/blob/main/LICENSE">MIT License</a>
       </div>
-      <p class="footer-copy">OpenCircom v0.7.0 · Jose (<a href="https://github.com/jose-compu">@jose-compu</a>)</p>
+      <p class="footer-copy">OpenCircom v0.8.0 · Jose (<a href="https://github.com/jose-compu">@jose-compu</a>)</p>
     </div>
   </footer>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,24 @@
 {
   "name": "opencircom",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencircom",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
+      "bin": {
+        "opencircom": "bin/opencircom.js"
+      },
       "devDependencies": {
         "chai": "^4.3.10",
         "circom_tester": "^0.0.21",
         "mocha": "^10.7.3",
         "snarkjs": "^0.7.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@iden3/bigarray": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencircom",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Reusable Circom ZK circuit templates — hashing, comparators, Merkle trees, and more. No dependency on circomlib.",
   "main": "index.js",
   "bin": {

--- a/scripts/gen_docs.js
+++ b/scripts/gen_docs.js
@@ -305,7 +305,7 @@ function renderDocumentationHtml(byCat) {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="OpenCircom v0.7.0 documentation — installation, CLI, Hardhat/Foundry integration, security, and full circuit template reference." />
+  <meta name="description" content="OpenCircom v0.8.0 documentation — installation, CLI, Hardhat/Foundry integration, security, and full circuit template reference." />
   <title>Documentation — OpenCircom</title>
   <link rel="icon" href="assets/img/logo.png" type="image/png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -342,12 +342,12 @@ function renderDocumentationHtml(byCat) {
       <header class="docs-header">
         <p class="section-label">Documentation</p>
         <h1>OpenCircom reference</h1>
-        <p class="docs-lead">v0.7.0 — ${templateCount} circuit templates, CLI tooling, integration guides, and auto-generated template reference from <code>circuits/**/*.circom</code>.</p>
+        <p class="docs-lead">v0.8.0 — ${templateCount} circuit templates, CLI tooling, integration guides, and auto-generated template reference from <code>circuits/**/*.circom</code>.</p>
       </header>
 
       <section class="docs-section" id="overview">
         <h2>Overview</h2>
-        <p>OpenCircom is a library of reusable <strong>Circom 2.x</strong> templates for zero-knowledge applications: hashing (Poseidon, MiMC, SHA-256), comparators, Merkle proofs, identity (Semaphore-style), voting, MACI v1 building blocks, and utilities. There is <strong>no dependency on circomlib</strong>; implementations are self-contained and covered by 153+ real Groth16 tests.</p>
+        <p>OpenCircom is a library of reusable <strong>Circom 2.x</strong> templates for zero-knowledge applications: hashing (Poseidon, MiMC, SHA-256), comparators, Merkle proofs, identity (Semaphore-style), voting, MACI v1 building blocks, and utilities. There is <strong>no dependency on circomlib</strong>; implementations are self-contained and covered by 163+ real Groth16 tests.</p>
         <p>Install via npm, add the circuits folder to your Circom include path (<code>-l</code>), and compose templates in your own circuits. Use the <a href="https://github.com/jose-compu/opencircom-hardhat-boilerplate" target="_blank" rel="noopener">Hardhat</a> or <a href="https://github.com/jose-compu/opencircom-foundry-boilerplate" target="_blank" rel="noopener">Foundry</a> boilerplates for a full compile → verifier → test pipeline.</p>
       </section>
 
@@ -355,7 +355,7 @@ function renderDocumentationHtml(byCat) {
         <h2>Installation</h2>
         <pre class="code-block"><code class="language-bash">npm install opencircom</code></pre>
         <p>Peer dependency: <strong>circom 2.x</strong> must be installed and available on <code>PATH</code>. OpenCircom does not bundle the compiler.</p>
-        <p>Package version: <code>^0.7.0</code>. Circuits live under <code>node_modules/opencircom/circuits/</code>.</p>
+        <p>Package version: <code>^0.8.0</code>. Circuits live under <code>node_modules/opencircom/circuits/</code>.</p>
       </section>
 
       <section class="docs-section" id="includes">
@@ -399,7 +399,7 @@ npx opencircom path</code></pre>
 
       <section class="docs-section" id="cli-ref">
         <h2>CLI reference</h2>
-        <p>The <code>opencircom</code> CLI ships with the npm package (v0.7.0+):</p>
+        <p>The <code>opencircom</code> CLI ships with the npm package (v0.7.0+; current <code>^0.8.0</code>):</p>
         <div class="docs-table-wrap">
           <table class="docs-table">
             <thead><tr><th>Command</th><th>Description</th></tr></thead>
@@ -429,10 +429,11 @@ npm test</code></pre>
         <h2>Security</h2>
         <ul class="docs-list">
           <li><strong>Range checks:</strong> Use <code>StrictNum2Bits(n)</code> or <code>RangeProof(n)</code> for untrusted inputs; <code>LessThan(n)</code> assumes inputs &lt; 2<sup>n</sup>.</li>
+          <li><strong>Binary selectors / bits:</strong> Prefer <code>SafeAND</code>, <code>SafeOR</code>, <code>SafeMux1</code>, <code>SafeMux2</code>, <code>SafeBits2Num(n)</code> for untrusted inputs. Raw AND/OR/Mux1/Mux2/Bits2Num are building blocks without binary constraints.</li>
           <li><strong>Merkle:</strong> <code>pathIndices[i]</code> are constrained binary in-circuit; <code>Switcher</code> constrains <code>sel</code> to {0,1}.</li>
           <li><strong>Nullifier:</strong> Use a unique <code>externalNullifier</code> per action to avoid cross-action replay.</li>
           <li><strong>Hashing:</strong> Poseidon uses standard Hades parameters; constants in <code>circuits/hashing/poseidon_constants.circom</code>.</li>
-          <li><strong>Audit (0.5.0):</strong> Binary constraints and range checks hardened in Switcher, ForceEqualIfEnabled, IncrementalMerkleInclusion, DivRem, and PadPKCS7.</li>
+          <li><strong>Audit (0.5.0) / Safe wrappers (0.8.0):</strong> Binary constraints and range checks hardened in Switcher, ForceEqualIfEnabled, IncrementalMerkleInclusion, DivRem, and PadPKCS7; Safe* templates added for gates, mux, and Bits2Num.</li>
           <li><strong>MACI:</strong> EdDSA, ECDH shared keys, and full DuplexSponge encryption remain off-circuit (coordinator layer). See <a href="https://maci.pse.dev/docs/v1.2/spec">MACI v1 spec</a>.</li>
         </ul>
         <p>Full notes: <a href="https://github.com/jose-compu/opencircom/blob/main/SECURITY.md">SECURITY.md</a> on GitHub.</p>
@@ -479,7 +480,7 @@ npm test</code></pre>
         <a href="https://www.npmjs.com/package/opencircom">npm</a>
         <a href="https://github.com/jose-compu/opencircom/blob/main/LICENSE">MIT License</a>
       </div>
-      <p class="footer-copy">OpenCircom v0.7.0 · Generated by <code>npm run docs</code></p>
+      <p class="footer-copy">OpenCircom v0.8.0 · Generated by <code>npm run docs</code></p>
     </div>
   </footer>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>

--- a/test/circuits/safe_wrappers_test.circom
+++ b/test/circuits/safe_wrappers_test.circom
@@ -1,0 +1,53 @@
+pragma circom 2.0.0;
+
+include "../../circuits/gates.circom";
+include "../../circuits/mux1.circom";
+include "../../circuits/mux2.circom";
+include "../../circuits/bitify.circom";
+
+template SafeWrappersTest() {
+    signal input a;
+    signal input b;
+    signal input c1[2];
+    signal input s1;
+    signal input c2[4];
+    signal input s2[2];
+    signal input bits[8];
+    signal output andOut;
+    signal output orOut;
+    signal output mux1Out;
+    signal output mux2Out;
+    signal output bits2NumOut;
+
+    component sand = SafeAND();
+    sand.a <== a;
+    sand.b <== b;
+    andOut <== sand.out;
+
+    component sor = SafeOR();
+    sor.a <== a;
+    sor.b <== b;
+    orOut <== sor.out;
+
+    component sm1 = SafeMux1();
+    sm1.c[0] <== c1[0];
+    sm1.c[1] <== c1[1];
+    sm1.s <== s1;
+    mux1Out <== sm1.out;
+
+    component sm2 = SafeMux2();
+    for (var i = 0; i < 4; i++) {
+        sm2.c[i] <== c2[i];
+    }
+    sm2.s[0] <== s2[0];
+    sm2.s[1] <== s2[1];
+    mux2Out <== sm2.out;
+
+    component sb2n = SafeBits2Num(8);
+    for (var i = 0; i < 8; i++) {
+        sb2n.in[i] <== bits[i];
+    }
+    bits2NumOut <== sb2n.out;
+}
+
+component main = SafeWrappersTest();

--- a/test/safe_wrappers_test.js
+++ b/test/safe_wrappers_test.js
@@ -1,0 +1,128 @@
+const chai = require("chai");
+const path = require("path");
+const wasm_tester = require("circom_tester").wasm;
+
+const assert = chai.assert;
+
+const BUILD = path.join(__dirname, "..", "build");
+
+function baseInput(overrides = {}) {
+  return {
+    a: 0,
+    b: 0,
+    c1: [10, 20],
+    s1: 0,
+    c2: [100, 200, 300, 400],
+    s2: [0, 0],
+    bits: [0, 0, 0, 0, 0, 0, 0, 0],
+    ...overrides,
+  };
+}
+
+describe("Safe wrappers (opencircom)", function () {
+  let circuit;
+  this.timeout(60000);
+
+  before(async () => {
+    circuit = await wasm_tester(path.join(__dirname, "circuits", "safe_wrappers_test.circom"), {
+      output: BUILD,
+      recompile: false,
+    });
+  });
+
+  it("SafeAND: 1,1 => 1; 0,1 => 0", async () => {
+    const w11 = await circuit.calculateWitness(baseInput({ a: 1, b: 1 }), true);
+    await circuit.checkConstraints(w11);
+    assert.equal(w11[1].toString(), "1");
+    const w01 = await circuit.calculateWitness(baseInput({ a: 0, b: 1 }), true);
+    await circuit.checkConstraints(w01);
+    assert.equal(w01[1].toString(), "0");
+  });
+
+  it("SafeOR: 0,0 => 0; 1,0 => 1; 1,1 => 1", async () => {
+    const w00 = await circuit.calculateWitness(baseInput({ a: 0, b: 0 }), true);
+    await circuit.checkConstraints(w00);
+    assert.equal(w00[2].toString(), "0");
+    const w10 = await circuit.calculateWitness(baseInput({ a: 1, b: 0 }), true);
+    assert.equal(w10[2].toString(), "1");
+    const w11 = await circuit.calculateWitness(baseInput({ a: 1, b: 1 }), true);
+    assert.equal(w11[2].toString(), "1");
+  });
+
+  it("SafeMux1: s=0 => c[0]; s=1 => c[1]", async () => {
+    const w0 = await circuit.calculateWitness(baseInput({ s1: 0 }), true);
+    await circuit.checkConstraints(w0);
+    assert.equal(w0[3].toString(), "10");
+    const w1 = await circuit.calculateWitness(baseInput({ s1: 1 }), true);
+    await circuit.checkConstraints(w1);
+    assert.equal(w1[3].toString(), "20");
+  });
+
+  it("SafeMux2: s selects c[s[0]+2*s[1]]", async () => {
+    const w0 = await circuit.calculateWitness(baseInput({ s2: [0, 0] }), true);
+    await circuit.checkConstraints(w0);
+    assert.equal(w0[4].toString(), "100");
+    const w3 = await circuit.calculateWitness(baseInput({ s2: [1, 1] }), true);
+    await circuit.checkConstraints(w3);
+    assert.equal(w3[4].toString(), "400");
+  });
+
+  it("SafeBits2Num(8) recomposes binary bits", async () => {
+    // 42 = 0b00101010, LSB first
+    const bits = [0, 1, 0, 1, 0, 1, 0, 0];
+    const w = await circuit.calculateWitness(baseInput({ bits }), true);
+    await circuit.checkConstraints(w);
+    assert.equal(w[5].toString(), "42");
+  });
+
+  it("SafeAND rejects non-binary a", async () => {
+    let failed = false;
+    try {
+      await circuit.calculateWitness(baseInput({ a: 2, b: 1 }), true);
+    } catch (_) {
+      failed = true;
+    }
+    assert.isTrue(failed);
+  });
+
+  it("SafeOR rejects non-binary b", async () => {
+    let failed = false;
+    try {
+      await circuit.calculateWitness(baseInput({ a: 1, b: 3 }), true);
+    } catch (_) {
+      failed = true;
+    }
+    assert.isTrue(failed);
+  });
+
+  it("SafeMux1 rejects non-binary selector", async () => {
+    let failed = false;
+    try {
+      await circuit.calculateWitness(baseInput({ s1: 2 }), true);
+    } catch (_) {
+      failed = true;
+    }
+    assert.isTrue(failed);
+  });
+
+  it("SafeMux2 rejects non-binary selector bit", async () => {
+    let failed = false;
+    try {
+      await circuit.calculateWitness(baseInput({ s2: [2, 0] }), true);
+    } catch (_) {
+      failed = true;
+    }
+    assert.isTrue(failed);
+  });
+
+  it("SafeBits2Num rejects non-binary bit", async () => {
+    let failed = false;
+    try {
+      const bits = [0, 1, 2, 0, 0, 0, 0, 0];
+      await circuit.calculateWitness(baseInput({ bits }), true);
+    } catch (_) {
+      failed = true;
+    }
+    assert.isTrue(failed);
+  });
+});


### PR DESCRIPTION
## TLDR

Add SafeAND, SafeOR, SafeMux1, SafeMux2, and SafeBits2Num so untrusted gate/mux/bit inputs are constrained in-circuit (#15).

## Summary
- Add `SafeAND()`, `SafeOR()`, `SafeMux1()`, `SafeMux2()`, and `SafeBits2Num(n)` that binary-constrain inputs before delegating to the raw building blocks.
- Document raw `AND`/`OR`/`Mux1`/`Mux2`/`Bits2Num` as building-block-only; recommend Safe* for untrusted inputs.
- Bump package to **0.8.0**; update README, SECURITY.md, CHANGELOG, and generated docs.

Closes #15

## Test plan
- [x] `npm test` — 165 passing (incl. Safe* functional + non-binary rejection cases)
- [ ] Spot-check `npx opencircom list` includes Safe* templates
- [ ] Confirm docs site shows v0.8.0 after merge