### PR TITLE
Harden VoteCommit choice and MACI nonce range checks

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "timeout": 120000,
+  "exit": true,
+  "spec": "test/*.js"
+}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Security: `VoteCommit` now `StrictNum2Bits(32)`-bounds `choice` before `LessThan(32)` (Fr wraparound could previously satisfy the range check). `#36`
+- Security: `MACIVoteDecryptVerify` range-checks `minValidNonce` with `StrictNum2Bits(50)` before `GreaterEqThan(50)`. `#36`
+
 ## 0.8.0
 
 - Safe wrappers for binary-constrained building blocks (#15): `SafeAND()`, `SafeOR()`, `SafeMux1()`, `SafeMux2()`, `SafeBits2Num(n)` — enforce 0/1 on gate inputs, mux selectors, and bit arrays.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,12 +36,19 @@
 ### Nullifier
 
 - `Nullifier(secret, externalNullifier)` is for one-time use per (`secret`, externalNullifier). Use a unique `externalNullifier` per action (e.g. poll id, withdrawal nonce).
+- `externalNullifier` and `ballotId` are Poseidon inputs (field elements). Distinct Fr values already hash distinctly; a bit-width bound does not add uniqueness.
+
+### Voting (`VoteCommit`, `VoteReveal`)
+
+- `VoteCommit(numChoices)` alias-checks `choice` with `StrictNum2Bits(32)` before `LessThan(32)`. Do not compare untrusted values with `LessThan(n)` alone (wraparound over Fr can satisfy `out === 1` for `choice >= 2^n`).
+- `VoteReveal` binds `choice` via `Poseidon(choice, identity, salt, ballotId) === commitment`. Enforce the ballot range at commit (or in the contract). `ballotId` uniqueness is an application-layer requirement.
 
 ### MACI building blocks
 
 - **Off-circuit coordinator**: Baby JubJub ECDH shared key, EdDSA sign `h_cm`, full MACI DuplexSponge encryption, message batch processing, and state/ballot tree updates remain application-layer ([MACI v1 spec](https://maci.pse.dev/docs/v1.2/spec)).
 - **In-circuit encryption** uses additive Poseidon keystream, not MACI DuplexSponge; interoperable command packing and `h_cm` match MACI v1.
-- **`MACIVoteDecryptVerify`**: enforce `minValidNonce` from ballot state; reject votes outside `allowedVoteOptions`; bind `expectedPollId`.
+- **`MACIVoteDecryptVerify`**: enforce `minValidNonce` from ballot state (in-circuit: `StrictNum2Bits(50)` then `GreaterEqThan(50)`); reject votes outside `allowedVoteOptions`; bind `expectedPollId`.
+- Ciphertext limbs are field elements from additive Poseidon keystream; they are not n-bit integers and must not be range-clipped.
 - **Nonce monotonicity**: MACI applies messages in reverse order; coordinator must track ballot nonces correctly.
 
 ## Audits

--- a/circuits/voting/maci_voting.circom
+++ b/circuits/voting/maci_voting.circom
@@ -290,7 +290,7 @@ template MACIVoteCommit() {
  * @custom:input packed Decrypted command prefix p from plaintext[0].
  * @custom:input voteOption, nonce, voteWeight, pollId, stateIndex — unpacked command fields.
  * @custom:input expectedPollId Public poll id from contract.
- * @custom:input minValidNonce Minimum valid nonce from ballot (blt_n + 1 in MACI).
+ * @custom:input minValidNonce Minimum valid nonce from ballot (blt_n + 1 in MACI); constrained to 50 bits.
  * @custom:input allowedVoteOptions[n] Valid vote option indices.
  * @custom:output valid 1 if all checks pass.
  */
@@ -333,6 +333,10 @@ template MACIVoteDecryptVerify(n) {
     component eqExpectedPoll = IsEqual();
     eqExpectedPoll.in[0] <== pollId;
     eqExpectedPoll.in[1] <== expectedPollId;
+
+    // nonce is 50-bit via unpack; minValidNonce is an untrusted public input.
+    component strictMinNonce = StrictNum2Bits(50);
+    strictMinNonce.in <== minValidNonce;
 
     component nonceOk = GreaterEqThan(50);
     nonceOk.in[0] <== nonce;

--- a/circuits/voting/vote_commit.circom
+++ b/circuits/voting/vote_commit.circom
@@ -14,15 +14,20 @@ include "../utils.circom";
  * @custom:input salt Random salt.
  * @custom:input ballotId Ballot identifier.
  * @custom:input commitment Public commitment (must match H(choice, revealIdentity, salt, ballotId)).
- * @custom:complexity LessThan(32) + Poseidon(4): ~330 constraints. Keep numChoices within 32-bit range.
- * @custom:security Commitment must be published and stored for reveal. choice in [0, numChoices) enforced; ensure ballotId is unique per ballot.
+ * @custom:complexity StrictNum2Bits(32) + LessThan(32) + Poseidon(4): ~370 constraints. Keep numChoices within 32-bit range.
+ * @custom:security Commitment must be published and stored for reveal. choice is alias-checked into [0, 2^32) then constrained to [0, numChoices). ballotId is a Poseidon input (field element); uniqueness is an application/contract concern.
  */
 template VoteCommit(numChoices) {
+    assert(numChoices >= 1 && numChoices < (1 << 32));
     signal input choice;
     signal input revealIdentity;
     signal input salt;
     signal input ballotId;
     signal input commitment;
+
+    // LessThan(32) is unsound unless both inputs are in [0, 2^32).
+    component strictChoice = StrictNum2Bits(32);
+    strictChoice.in <== choice;
 
     component range = LessThan(32);
     range.in[0] <== choice;

--- a/circuits/voting/vote_reveal.circom
+++ b/circuits/voting/vote_reveal.circom
@@ -14,7 +14,7 @@ include "../merkle/merkle_inclusion.circom";
  * @custom:input commitment Commitment (must equal H(choice, identity, salt, ballotId)).
  * @custom:output nullifierHash Nullifier hash for double-vote prevention.
  * @custom:complexity Poseidon(4) + Poseidon(2) + Nullifier(1): ~780 constraints. Dominated by hashes.
- * @custom:security Contract must verify commitment was in committed set and nullifier not already spent. Same (identity, salt, ballotId) yields same nullifier (double-vote detection).
+ * @custom:security Contract must verify commitment was in committed set and nullifier not already spent. Same (identity, salt, ballotId) yields same nullifier (double-vote detection). choice is bound by the Poseidon commitment (range-checked in VoteCommit); ballotId is a field-element hash input.
  */
 template VoteReveal() {
     signal input choice;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "setup:zk": "bash scripts/setup_zk_tests.sh",
     "compile:test": "bash scripts/compile_test_circuits.sh",
-    "test": "npm run compile:test && npm run setup:zk && mocha test/*.js --timeout 120000",
+    "test": "npm run compile:test && npm run setup:zk && mocha",
     "docs": "node scripts/gen_docs.js"
   },
   "keywords": ["circom", "zk", "zero-knowledge", "snark", "poseidon", "merkle", "circuit"],

--- a/test/maci_voting_test.js
+++ b/test/maci_voting_test.js
@@ -267,6 +267,34 @@ describe("MACI vote building blocks (opencircom)", function () {
       assert.equal(w[1].toString(), "0");
     });
 
+    it("fails when minValidNonce is not a 50-bit integer", async () => {
+      const stateIndex = 1;
+      const voteOption = 2;
+      const nonce = 3;
+      const voteWeight = 1;
+      const pollId = 10;
+      const packed = maciPack(stateIndex, voteOption, nonce, voteWeight, pollId);
+      try {
+        await decryptVerifyCircuit.calculateWitness(
+          {
+            packed,
+            voteOption,
+            nonce,
+            voteWeight,
+            pollId,
+            stateIndex,
+            expectedPollId: pollId,
+            minValidNonce: (1n << 50n).toString(),
+            allowedVoteOptions: [0, 2, 5],
+          },
+          true
+        );
+        assert.fail("should have thrown for minValidNonce >= 2^50");
+      } catch (e) {
+        assert.isOk(e);
+      }
+    });
+
     it("fails when nonce below minValidNonce", async () => {
       const stateIndex = 1;
       const voteOption = 2;

--- a/test/voting_test.js
+++ b/test/voting_test.js
@@ -102,6 +102,26 @@ describe("Voting (commit-reveal, nullifier)", function () {
       }
     });
 
+    it("fails when choice wraps LessThan(32) over Fr (p - 2^32 + numChoices)", async () => {
+      // BN254 scalar field. Without StrictNum2Bits, LessThan(32) accepts this as < numChoices.
+      const p = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+      const numChoices = 5n;
+      const choice = (p - (1n << 32n) + numChoices).toString();
+      const revealIdentity = 1;
+      const salt = 2;
+      const ballotId = 3;
+      const commitment = await poseidon4(poseidon4Circuit, choice, revealIdentity, salt, ballotId);
+      try {
+        await commitCircuit.calculateWitness(
+          { choice, revealIdentity, salt, ballotId, commitment },
+          true
+        );
+        assert.fail("should have thrown for Fr-wraparound choice");
+      } catch (e) {
+        assert.isOk(e);
+      }
+    });
+
     it("same inputs give same commitment", async () => {
       const choice = 1;
       const revealIdentity = 100;

--- a/test/zk_real_test.js
+++ b/test/zk_real_test.js
@@ -63,4 +63,11 @@ describe("ZK real (Groth16 prove & verify)", function () {
     const ok = await snarkjs.groth16.verify(vkey, publicSignals, proof);
     assert.isTrue(ok, "Groth16 verify must pass for valid proof");
   });
+
+  after(async function () {
+    // ffjavascript/snarkjs keep a curve worker open after prove/verify.
+    if (globalThis.curve_bn128) {
+      await globalThis.curve_bn128.terminate();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #36: `VoteCommit` now `StrictNum2Bits(32)`-bounds `choice` before `LessThan(32)`, so Fr wraparound can no longer satisfy the range check.
- `MACIVoteDecryptVerify` range-checks `minValidNonce` with `StrictNum2Bits(50)` before `GreaterEqThan(50)`.
- Documents why `ballotId`, ciphertext, and `externalNullifier` do not need bit-width bounds.

## Test plan
- [x] `npx mocha test/voting_test.js test/maci_voting_test.js --timeout 120000` (19 passing)
- [ ] Confirm wraparound `choice = p - 2^32 + numChoices` is rejected
- [ ] Confirm `minValidNonce >= 2^50` is rejected
